### PR TITLE
Add architecture context overlays format

### DIFF
--- a/AGENT_USAGE.md
+++ b/AGENT_USAGE.md
@@ -9,6 +9,9 @@ All generated architecture data lives under `./architecture/`. The `checkouts/` 
 ## Directory Layout
 
 ```
+overlays/                             # Architecture updates between regeneration cycles
+  README.md
+  NNNN-short-description.md
 architecture/
   rhoai-{version}/                  # One directory per analyzed version
     {component}.md                  # Component architecture document (structured markdown)
@@ -93,6 +96,27 @@ Each component has up to 6 diagram files in the `diagrams/` subdirectory:
 | `{component}-c4-context.dsl` | Structurizr DSL | C4 model context diagram showing external actors and systems |
 
 PNG renders (`*.png`) are pre-generated from the Mermaid sources.
+
+## Overlays (`overlays/`)
+
+Overlays are architecture updates that correct or extend the generated docs between regeneration cycles. When a version bump, maturity change, or dependency shift happens and the architecture docs haven't been regenerated yet, an overlay captures the fact so consumers use current information.
+
+```
+overlays/
+  README.md                              # Format docs, naming convention, lifecycle
+  0001-kfp-sdk-2.16-in-rhoai-3.4.md     # Example overlay
+```
+
+Each overlay is a Markdown file with YAML frontmatter (`status`, `affects`, `release`, `provenance`, `author`) and three body sections (`## Fact`, `## Impact on Strategies`, `## Context`).
+
+### How to use overlays
+
+- **Read active overlays before trusting generated docs**: check `overlays/*.md` for any with `status: active` that affect the components you're looking at. Active overlays take precedence over the generated architecture docs when they conflict.
+- **Filter by component**: the `affects` field lists which components an overlay applies to. Match against the component you're researching.
+- **Filter by release**: the `release` field scopes overlays to specific RHOAI versions. Use `"all"` for timeless facts.
+- **Ignore superseded overlays**: overlays with `status: superseded` have been absorbed into the regenerated docs and can be skipped.
+
+See `overlays/README.md` for the full format specification.
 
 ## The `checkouts/` Directory (Local Only)
 

--- a/overlays/0001-kfp-sdk-2.16-in-rhoai-3.4.md
+++ b/overlays/0001-kfp-sdk-2.16-in-rhoai-3.4.md
@@ -1,5 +1,5 @@
 ---
-id: "001"
+id: "0001"
 title: KFP SDK updated to 2.16 in RHOAI 3.4
 status: active
 created: 2026-04-20
@@ -17,7 +17,7 @@ superseded_by: null
 
 ## Fact
 
-KFP SDK was updated from 2.15 to 2.16 in RHOAI 3.4, shipped in the data-science-pipelines-operator via PR #1007.
+KFP SDK was updated from 2.5 to 2.16 in RHOAI 3.4, shipped in the data-science-pipelines-operator via PR #1007.
 
 ## Impact on Strategies
 

--- a/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
+++ b/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
@@ -22,7 +22,7 @@ KFP SDK was updated from 2.15 to 2.16 in RHOAI 3.4, shipped in the data-science-
 ## Impact on Strategies
 
 - Reference KFP SDK **2.16** for RHOAI 3.5 strategies 
-- Notebook images that bundle the KFP SDK (e.g., KALE workbench) should pin to 2.16
+- Notebook images will use KFP SDK 2.16
 - Acceptance criteria referencing SDK version should specify 2.16
 
 ## Context

--- a/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
+++ b/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
@@ -1,6 +1,6 @@
 ---
 id: "001"
-title: KFP SDK updated to 2.16 in RHOAI 3.5
+title: KFP SDK updated to 2.16 in RHOAI 3.4
 status: active
 created: 2026-04-20
 affects:
@@ -8,9 +8,10 @@ affects:
   - data-science-pipelines-operator
   - notebooks
 release:
-  - "3.5"
+  - "3.4"
 provenance:
   - https://github.com/opendatahub-io/data-science-pipelines-operator/pull/1007
+author: Eder Ignatowicz
 superseded_by: null
 ---
 
@@ -20,8 +21,7 @@ KFP SDK was updated from 2.15 to 2.16 in RHOAI 3.4, shipped in the data-science-
 
 ## Impact on Strategies
 
-- Reference KFP SDK **2.16**, not 2.15, for RHOAI 3.5 strategies
-- The v2beta1 REST API surface is unchanged; the SDK update is a client-side change
+- Reference KFP SDK **2.16**, not 2.15, for RHOAI 3.5 strategies 
 - Notebook images that bundle the KFP SDK (e.g., KALE workbench) should pin to 2.16
 - Acceptance criteria referencing SDK version should specify 2.16
 

--- a/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
+++ b/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
@@ -27,4 +27,4 @@ KFP SDK was updated from 2.15 to 2.16 in RHOAI 3.4, shipped in the data-science-
 
 ## Context
 
-The architecture context docs were generated from rhoai-3.4 branches and still reference KFP SDK 2.15. The 3.5 branch has not been analyzed yet. This overlay bridges the gap until the architecture context is regenerated for 3.5.
+The latest architecture context docs (rhoai-3.4-ea.2) reference KFP SDK 2.15 in `notebooks.md`. This overlay corrects that to 2.16 per the upstream PR merged into data-science-pipelines-operator.

--- a/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
+++ b/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
@@ -21,7 +21,7 @@ KFP SDK was updated from 2.15 to 2.16 in RHOAI 3.4, shipped in the data-science-
 
 ## Impact on Strategies
 
-- Reference KFP SDK **2.16**, not 2.15, for RHOAI 3.5 strategies 
+- Reference KFP SDK **2.16** for RHOAI 3.5 strategies 
 - Notebook images that bundle the KFP SDK (e.g., KALE workbench) should pin to 2.16
 - Acceptance criteria referencing SDK version should specify 2.16
 

--- a/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
+++ b/overlays/001-kfp-sdk-2.16-in-rhoai-3.5.md
@@ -1,0 +1,30 @@
+---
+id: "001"
+title: KFP SDK updated to 2.16 in RHOAI 3.5
+status: active
+created: 2026-04-20
+affects:
+  - data-science-pipelines
+  - data-science-pipelines-operator
+  - notebooks
+release:
+  - "3.5"
+provenance:
+  - https://github.com/opendatahub-io/data-science-pipelines-operator/pull/1007
+superseded_by: null
+---
+
+## Fact
+
+KFP SDK was updated from 2.15 to 2.16 in RHOAI 3.4, shipped in the data-science-pipelines-operator via PR #1007.
+
+## Impact on Strategies
+
+- Reference KFP SDK **2.16**, not 2.15, for RHOAI 3.5 strategies
+- The v2beta1 REST API surface is unchanged; the SDK update is a client-side change
+- Notebook images that bundle the KFP SDK (e.g., KALE workbench) should pin to 2.16
+- Acceptance criteria referencing SDK version should specify 2.16
+
+## Context
+
+The architecture context docs were generated from rhoai-3.4 branches and still reference KFP SDK 2.15. The 3.5 branch has not been analyzed yet. This overlay bridges the gap until the architecture context is regenerated for 3.5.

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -23,7 +23,7 @@ Each overlay is a Markdown file with YAML frontmatter:
 
 ```yaml
 ---
-id: "001"
+id: "0001"
 title: Short description of the fact
 status: active                    # active | superseded
 created: 2026-04-20
@@ -55,15 +55,15 @@ an older state because the newer branch hasn't been analyzed yet.
 
 ## Naming Convention
 
-`NNN-short-kebab-description.md`
+`NNNN-short-kebab-description.md`
 
-- `NNN`: Zero-padded three-digit sequence number (insertion order)
+- `NNNN`: Zero-padded four-digit sequence number (insertion order)
 - Description: Kebab-case summary of the fact
 
 Examples:
-- `001-kfp-sdk-2.16-in-rhoai-3.5.md`
-- `002-kale-dev-preview-rhoai-3.5.md`
-- `003-gateway-api-replaces-istio-ingress.md`
+- `0001-kfp-sdk-2.16-in-rhoai-3.5.md`
+- `0002-kale-dev-preview-rhoai-3.5.md`
+- `0003-gateway-api-replaces-istio-ingress.md`
 
 ## Matching
 

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -1,6 +1,8 @@
 # Architecture Context Overlays
 
-Overlays are architectural patches that apply across all strategy documents. They capture facts that emerged between architecture context regeneration cycles — version bumps, maturity changes, dependency shifts, platform decisions — so the strategy pipeline uses current information even when the generated architecture docs haven't caught up yet.
+Overlays are architectural patches that correct or extend the generated architecture docs. They capture facts that emerged between regeneration cycles — version bumps, maturity changes, dependency shifts, platform decisions — so consumers of this repo use current information even when the generated docs haven't caught up yet.
+
+Overlays are consumed by any tooling that reads from this repo (strategy pipelines, architecture reviews, design validation). Each consumer decides how to match and prioritize overlays in its own context.
 
 ## When to Write an Overlay
 
@@ -8,23 +10,12 @@ Write an overlay when:
 - A component version changed (e.g., SDK bump, upstream release)
 - A feature's maturity level shifted (e.g., Dev Preview, GA)
 - A dependency was added, removed, or deprecated
-- A platform-wide decision was made that affects multiple strategies
+- A platform-wide decision was made that affects multiple components
 - The generated architecture docs are missing or wrong about something
 
 Do **not** write an overlay for:
-- Strategy-specific corrections — use `## Staff Engineer Input` in the strategy file
 - Information already in the current architecture docs — overlays patch gaps, not duplicates
-
-## Priority Chain
-
-Overlays sit in the middle of the input priority chain for strategy refinement:
-
-1. **Staff Engineer Input** — per-strategy, human-authored (highest priority)
-2. **Architecture Context Overlays** — cross-strategy corrections (this)
-3. **Removed RFE Context** — per-RFE implementation details
-4. **Architecture Context** — generated platform docs (lowest priority)
-
-Staff Engineer Input in a specific strategy can override an overlay. Overlays override the generated architecture context.
+- Corrections scoped to a single downstream artifact — handle those in the consuming tool
 
 ## File Format
 
@@ -43,7 +34,7 @@ release:                          # RHOAI releases this applies to
   - "3.5"                         # use "all" for timeless facts
 provenance:                       # links to PRs, issues, decisions
   - https://github.com/org/repo/pull/123
-author: Your Name                   # who created this overlay
+author: Your Name                 # who created this overlay
 superseded_by: null               # set when status changes to superseded
 ---
 
@@ -53,7 +44,7 @@ What changed, in 1-3 sentences. Include the specific version, PR, or decision.
 
 ## Impact on Strategies
 
-- Bullet list of what strategies should do differently
+- Bullet list of how this affects downstream consumers
 - Be specific: "use X, not Y" rather than "update references"
 
 ## Context
@@ -68,9 +59,9 @@ an older state because the newer branch hasn't been analyzed yet.
 |-------|----------|------|-------------|
 | `id` | Yes | string | Three-digit sequence number (`"001"`, `"002"`, ...) |
 | `title` | Yes | string | Short description of the architectural fact |
-| `status` | Yes | enum | `active` (pipeline reads it) or `superseded` (pipeline ignores it) |
+| `status` | Yes | enum | `active` (consumers read it) or `superseded` (consumers ignore it) |
 | `created` | Yes | string | Date created (YYYY-MM-DD) |
-| `affects` | Yes | list | Component names from `architecture/*.md`. Use `platform` for all strategies |
+| `affects` | Yes | list | Component names from `architecture/*.md`. Use `platform` for platform-wide facts |
 | `release` | Yes | list | RHOAI release versions (e.g., `["3.5"]`). Use `["all"]` for timeless facts |
 | `provenance` | Yes | list | URLs to PRs, issues, or decisions establishing this fact |
 | `author` | Yes | string | Name of the person who created the overlay |
@@ -88,21 +79,19 @@ Examples:
 - `002-kale-dev-preview-rhoai-3.5.md`
 - `003-gateway-api-replaces-istio-ingress.md`
 
-## Pipeline Matching
+## Matching
 
-The strategy pipeline matches overlays to strategies using **component intersection**:
+Consumers match overlays using the frontmatter fields:
 
-1. Read all overlay files with `status: active`
-2. Filter by `release` — overlay's release list must include the target release or `"all"`
-3. Match `affects` — overlay's component list must intersect with the strategy's Affected Components table
-4. Overlays with `affects: [platform]` match all strategies
-
-Matched overlays' `## Fact` and `## Impact on Strategies` sections are injected into the refinement and review context.
+1. **Status**: Only `active` overlays are consumed
+2. **Release**: Filter by target release version or `"all"`
+3. **Component**: Match `affects` list against the components relevant to the consumer's task
+4. Overlays with `affects: [platform]` apply to all components
 
 ## Lifecycle
 
-- **active**: The pipeline reads and applies this overlay during refine and review
-- **superseded**: The architecture context has caught up (regenerated with the correct information). Change `status` to `superseded`, set `superseded_by` to explain why. The file stays for audit trail; the pipeline ignores it.
+- **active**: Consumers read and apply this overlay
+- **superseded**: The architecture context has caught up (regenerated with the correct information). Change `status` to `superseded`, set `superseded_by` to explain why. The file stays for audit trail; consumers ignore it.
 
 Mark an overlay superseded when:
 - The architecture context is regenerated and includes the fact

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -1,0 +1,108 @@
+# Architecture Context Overlays
+
+Overlays are architectural patches that apply across all strategy documents. They capture facts that emerged between architecture context regeneration cycles — version bumps, maturity changes, dependency shifts, platform decisions — so the strategy pipeline uses current information even when the generated architecture docs haven't caught up yet.
+
+## When to Write an Overlay
+
+Write an overlay when:
+- A component version changed (e.g., SDK bump, upstream release)
+- A feature's maturity level shifted (e.g., Dev Preview, GA)
+- A dependency was added, removed, or deprecated
+- A platform-wide decision was made that affects multiple strategies
+- The generated architecture docs are missing or wrong about something
+
+Do **not** write an overlay for:
+- Strategy-specific corrections — use `## Staff Engineer Input` in the strategy file
+- Information already in the current architecture docs — overlays patch gaps, not duplicates
+
+## Priority Chain
+
+Overlays sit in the middle of the input priority chain for strategy refinement:
+
+1. **Staff Engineer Input** — per-strategy, human-authored (highest priority)
+2. **Architecture Context Overlays** — cross-strategy corrections (this)
+3. **Removed RFE Context** — per-RFE implementation details
+4. **Architecture Context** — generated platform docs (lowest priority)
+
+Staff Engineer Input in a specific strategy can override an overlay. Overlays override the generated architecture context.
+
+## File Format
+
+Each overlay is a Markdown file with YAML frontmatter:
+
+```yaml
+---
+id: "001"
+title: Short description of the fact
+status: active                    # active | superseded
+created: 2026-04-20
+affects:                          # component names matching architecture/*.md
+  - data-science-pipelines
+  - notebooks
+release:                          # RHOAI releases this applies to
+  - "3.5"                         # use "all" for timeless facts
+provenance:                       # links to PRs, issues, decisions
+  - https://github.com/org/repo/pull/123
+superseded_by: null               # set when status changes to superseded
+---
+
+## Fact
+
+What changed, in 1-3 sentences. Include the specific version, PR, or decision.
+
+## Impact on Strategies
+
+- Bullet list of what strategies should do differently
+- Be specific: "use X, not Y" rather than "update references"
+
+## Context
+
+Why this overlay exists. Typically: the generated architecture docs reference
+an older state because the newer branch hasn't been analyzed yet.
+```
+
+## Frontmatter Fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `id` | Yes | string | Three-digit sequence number (`"001"`, `"002"`, ...) |
+| `title` | Yes | string | Short description of the architectural fact |
+| `status` | Yes | enum | `active` (pipeline reads it) or `superseded` (pipeline ignores it) |
+| `created` | Yes | string | Date created (YYYY-MM-DD) |
+| `affects` | Yes | list | Component names from `architecture/*.md`. Use `platform` for all strategies |
+| `release` | Yes | list | RHOAI release versions (e.g., `["3.5"]`). Use `["all"]` for timeless facts |
+| `provenance` | Yes | list | URLs to PRs, issues, or decisions establishing this fact |
+| `superseded_by` | No | string | Explanation or link when marking as superseded |
+
+## Naming Convention
+
+`NNN-short-kebab-description.md`
+
+- `NNN`: Zero-padded three-digit sequence number (insertion order)
+- Description: Kebab-case summary of the fact
+
+Examples:
+- `001-kfp-sdk-2.16-in-rhoai-3.5.md`
+- `002-kale-dev-preview-rhoai-3.5.md`
+- `003-gateway-api-replaces-istio-ingress.md`
+
+## Pipeline Matching
+
+The strategy pipeline matches overlays to strategies using **component intersection**:
+
+1. Read all overlay files with `status: active`
+2. Filter by `release` — overlay's release list must include the target release or `"all"`
+3. Match `affects` — overlay's component list must intersect with the strategy's Affected Components table
+4. Overlays with `affects: [platform]` match all strategies
+
+Matched overlays' `## Fact` and `## Impact on Strategies` sections are injected into the refinement and review context.
+
+## Lifecycle
+
+- **active**: The pipeline reads and applies this overlay during refine and review
+- **superseded**: The architecture context has caught up (regenerated with the correct information). Change `status` to `superseded`, set `superseded_by` to explain why. The file stays for audit trail; the pipeline ignores it.
+
+Mark an overlay superseded when:
+- The architecture context is regenerated and includes the fact
+- The fact is no longer true (e.g., a version was reverted)
+- A newer overlay replaces it with updated information

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -43,6 +43,7 @@ release:                          # RHOAI releases this applies to
   - "3.5"                         # use "all" for timeless facts
 provenance:                       # links to PRs, issues, decisions
   - https://github.com/org/repo/pull/123
+author: Your Name                   # who created this overlay
 superseded_by: null               # set when status changes to superseded
 ---
 
@@ -72,6 +73,7 @@ an older state because the newer branch hasn't been analyzed yet.
 | `affects` | Yes | list | Component names from `architecture/*.md`. Use `platform` for all strategies |
 | `release` | Yes | list | RHOAI release versions (e.g., `["3.5"]`). Use `["all"]` for timeless facts |
 | `provenance` | Yes | list | URLs to PRs, issues, or decisions establishing this fact |
+| `author` | Yes | string | Name of the person who created the overlay |
 | `superseded_by` | No | string | Explanation or link when marking as superseded |
 
 ## Naming Convention

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -1,6 +1,6 @@
 # Architecture Context Overlays
 
-Overlays are architectural patches that correct or extend the generated architecture docs. They capture facts that emerged between regeneration cycles — version bumps, maturity changes, dependency shifts, platform decisions — so consumers of this repo use current information even when the generated docs haven't caught up yet.
+Overlays are architecture updates that correct or extend the generated architecture docs. They capture facts that emerged between regeneration cycles — version bumps, maturity changes, dependency shifts, platform decisions — so consumers of this repo use current information even when the generated docs haven't caught up yet.
 
 Overlays are consumed by any tooling that reads from this repo (strategy pipelines, architecture reviews, design validation). Each consumer decides how to match and prioritize overlays in its own context.
 

--- a/overlays/README.md
+++ b/overlays/README.md
@@ -53,20 +53,6 @@ Why this overlay exists. Typically: the generated architecture docs reference
 an older state because the newer branch hasn't been analyzed yet.
 ```
 
-## Frontmatter Fields
-
-| Field | Required | Type | Description |
-|-------|----------|------|-------------|
-| `id` | Yes | string | Three-digit sequence number (`"001"`, `"002"`, ...) |
-| `title` | Yes | string | Short description of the architectural fact |
-| `status` | Yes | enum | `active` (consumers read it) or `superseded` (consumers ignore it) |
-| `created` | Yes | string | Date created (YYYY-MM-DD) |
-| `affects` | Yes | list | Component names from `architecture/*.md`. Use `platform` for platform-wide facts |
-| `release` | Yes | list | RHOAI release versions (e.g., `["3.5"]`). Use `["all"]` for timeless facts |
-| `provenance` | Yes | list | URLs to PRs, issues, or decisions establishing this fact |
-| `author` | Yes | string | Name of the person who created the overlay |
-| `superseded_by` | No | string | Explanation or link when marking as superseded |
-
 ## Naming Convention
 
 `NNN-short-kebab-description.md`


### PR DESCRIPTION
## Summary

- Adds `overlays/` directory for architecture updates that correct or extend generated docs between regeneration cycles
- Includes `README.md` documenting the overlay format, naming convention, matching rules, and lifecycle
- Includes first overlay (`0001-kfp-sdk-2.16-in-rhoai-3.4.md`): KFP SDK updated from 2.5 to 2.16 in RHOAI 3.4

## Why

When architectural facts change between regeneration cycles (version bumps, maturity shifts, dependency changes), there's no place to record them in this repo. Overlays fill that gap — consumers (strategy pipelines, architecture reviews) pick them up alongside the generated docs.

## Format

Each overlay is a Markdown file with YAML frontmatter (`status`, `affects`, `release`, `provenance`, `author`) and three body sections (`## Fact`, `## Impact on Strategies`, `## Context`). Active overlays are consumed; superseded ones are ignored but kept for audit trail.

## Test plan

- [ ] Verify overlay format renders correctly on GitHub
- [ ] Verify sparse checkout includes `overlays/` when fetched by downstream consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Architecture Context Overlays framework for systematically documenting and managing architectural decisions, version specifications, and their strategic impact across releases and components.
  * Added initial overlay for RHOAI 3.4, specifying KFP SDK version requirements, strategy guidance, and acceptance criteria for affected data science and notebook components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->