### PR TITLE
Add Training Hub architecture context for rhoai.next

### DIFF
--- a/overlays/0009-training-hub-fine-tuning-stack-integration.md
+++ b/overlays/0009-training-hub-fine-tuning-stack-integration.md
@@ -10,9 +10,8 @@ affects:
   - fms-hf-tuning
   - platform
 release:
-  - "rhoai-3.4-ea.2"
-  - "rhoai-3.4"
-  - "rhoai-3.5-ea.1"
+  - "3.4"
+  - "3.5"
   - "next"
 provenance:
   - https://redhat.atlassian.net/browse/RHOAIENG-62210

--- a/overlays/0009-training-hub-fine-tuning-stack-integration.md
+++ b/overlays/0009-training-hub-fine-tuning-stack-integration.md
@@ -1,0 +1,49 @@
+---
+id: "0009"
+title: Training Hub and fine-tuning stack integration context
+status: active
+created: 2026-05-13
+affects:
+  - training-hub
+  - trainer
+  - training-operator
+  - fms-hf-tuning
+  - platform
+release:
+  - "rhoai-3.4-ea.2"
+  - "rhoai-3.4"
+  - "rhoai-3.5-ea.1"
+  - "next"
+provenance:
+  - https://redhat.atlassian.net/browse/RHOAIENG-62210
+author: Fiona Waters
+superseded_by: null
+---
+
+## Fact
+
+Training Hub (Red-Hat-AI-Innovation-Team/training_hub) is a Python library providing a unified API for LLM post-training algorithms. It is pre-installed in Kubeflow SDK universal images and runs inside training pods orchestrated by the Kubeflow Training Operator (KFTO) via PyTorchJob or by Trainer v2 via TrainJob/ClusterTrainingRuntime. Training Hub is not a standalone service; it has no ingress, no CRDs, and no operator. Integration into the Ray component is upcoming.
+
+The RHOAI fine-tuning stack has four components that existing architecture docs do not cross-reference:
+
+| Component | Role | Algorithms |
+|-----------|------|------------|
+| **Training Hub** | High-level Python API; algorithm-backend abstraction | SFT, OSFT, LoRA+SFT, LoRA+GRPO, full GRPO (DPO planned) |
+| **fms-hf-tuning** | Lower-level container library for SFT | SFT, LoRA, QLoRA, Prompt Tuning |
+| **Kubeflow Trainer v2** | Kubernetes operator creating TrainJob/ClusterTrainingRuntime | N/A (orchestration, not algorithms) |
+| **Kubeflow Training Operator (KFTO)** | Legacy operator creating PyTorchJob/MPIJob | N/A (orchestration, not algorithms) |
+
+Training Hub and fms-hf-tuning are independent libraries that both run inside KFTO/Trainer pods. Training Hub is the higher-level abstraction supporting multiple algorithms and backends (InstructLab Training, Mini-Trainer, Unsloth, OpenPipe ART, verl). fms-hf-tuning is a narrower SFT-focused library using HuggingFace Transformers + TRL.
+
+Training Hub first ships as a pip dependency (`training_hub[lora]==0.6.0`) in the `distributed-workloads` universal training images starting from rhoai-3.4-ea.2. It is not present in rhoai-3.4-ea.1 or earlier.
+
+## Impact on Strategies
+
+- The end-to-end training lifecycle is: user defines TrainJob (Trainer v2) or PyTorchJob (KFTO) -> operator creates pods with universal training images -> Training Hub or fms-hf-tuning runs inside the pod -> results written to checkpoints. Architecture reviews and RFE feasibility assessments should trace this full path.
+- Training Hub, fms-hf-tuning, and KFTO/Trainer v2 are independent components with separate roadmaps. Training Hub and fms-hf-tuning both provide training algorithms; KFTO and Trainer v2 handle orchestration.
+- Training Hub supports two GRPO backends: ART (single-GPU, fast iteration) and verl (multi-GPU, scales to 70B+). Backend choice affects GPU resource requirements and should be factored into capacity planning.
+- The existing `trainer.md`, `training-operator.md`, and `fms-hf-tuning.md` architecture docs do not mention Training Hub. Until regeneration adds this context, treat this overlay as the integration reference.
+
+## Context
+
+RHOAIENG-62210 investigated whether the fine-tuning domain is adequately represented in architecture context. The generated component docs for trainer, training-operator, and fms-hf-tuning each describe their own component in isolation but do not explain how they compose. Training Hub was not previously included in the architecture-context pipeline. This overlay bridges the gap until the next architecture regeneration cycle incorporates Training Hub references into the related component docs.

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -86,6 +86,8 @@ rhoai.next:
       repo: codeflare-sdk
     - org: IBM
       repo: ai4rag
+    - org: Red-Hat-AI-Innovation-Team
+      repo: training_hub
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -95,6 +97,10 @@ rhoai.next:
     - key: ai4rag
       repo_org: IBM
       repo_name: ai4rag
+      type: library
+    - key: training-hub
+      repo_org: Red-Hat-AI-Innovation-Team
+      repo_name: training_hub
       type: library
 
 rhoai-3.5-ea.1:
@@ -106,6 +112,8 @@ rhoai-3.5-ea.1:
       repo: codeflare-sdk
     - org: IBM
       repo: ai4rag
+    - org: Red-Hat-AI-Innovation-Team
+      repo: training_hub
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -115,6 +123,10 @@ rhoai-3.5-ea.1:
     - key: ai4rag
       repo_org: IBM
       repo_name: ai4rag
+      type: library
+    - key: training-hub
+      repo_org: Red-Hat-AI-Innovation-Team
+      repo_name: training_hub
       type: library
 
 rhoai-3.4:
@@ -126,6 +138,8 @@ rhoai-3.4:
       repo: codeflare-sdk
     - org: IBM
       repo: ai4rag
+    - org: Red-Hat-AI-Innovation-Team
+      repo: training_hub
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -135,6 +149,10 @@ rhoai-3.4:
     - key: ai4rag
       repo_org: IBM
       repo_name: ai4rag
+      type: library
+    - key: training-hub
+      repo_org: Red-Hat-AI-Innovation-Team
+      repo_name: training_hub
       type: library
 
 rhoai-3.4-ea.2:
@@ -146,6 +164,8 @@ rhoai-3.4-ea.2:
       repo: codeflare-sdk
     - org: IBM
       repo: ai4rag
+    - org: Red-Hat-AI-Innovation-Team
+      repo: training_hub
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -155,6 +175,10 @@ rhoai-3.4-ea.2:
     - key: ai4rag
       repo_org: IBM
       repo_name: ai4rag
+      type: library
+    - key: training-hub
+      repo_org: Red-Hat-AI-Innovation-Team
+      repo_name: training_hub
       type: library
 
 rhoai-3.4-ea.1:


### PR DESCRIPTION
## Summary

- Add Training Hub (`Red-Hat-AI-Innovation-Team/training_hub`) to `platforms.yaml` as an `extra_repo` + `include_component` (type: library) for `rhoai.next`, following the ai4rag pattern
- Generate architecture doc (`architecture/rhoai.next/training-hub.md`) covering all algorithms (SFT, OSFT, LoRA+SFT, LoRA+GRPO, full GRPO), backends, profiling utilities, and integration points
- Generate component diagrams (component, dataflow, dependencies, security-network, RBAC, C4 context)
- Add overlay `0005-training-hub-fine-tuning-stack-integration.md` documenting how Training Hub integrates with the existing fine-tuning stack (Trainer v2, KFTO, fms-hf-tuning)

Addresses [RHOAIENG-62210](https://redhat.atlassian.net/browse/RHOAIENG-62210)

## Test plan

- [ ] Verify `training-hub.md` architecture doc is complete and accurate
- [ ] Verify Mermaid diagrams render correctly (paste into https://mermaid.live)
- [ ] Verify overlay follows the format in `overlays/README.md`
- [ ] Verify `platforms.yaml` change matches the ai4rag pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated the Training Hub component into multiple RHOAI platform releases (rhoai.next, rhoai-3.5-ea.1, rhoai-3.4, rhoai-3.4-ea.2) to enable unified post-training capabilities.

* **Documentation**
  * Added an integration overlay describing Training Hub’s role in the fine-tuning stack, supported algorithms/backends, lifecycle (job → pod → in-pod execution → checkpoints), packaging in distributed-workloads images from rhoai-3.4-ea.2, and guidance for orchestration and capacity planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->