### PR TITLE
add declarative exclude_files for post-checkout cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@2d2e96d11f9b3d2a35266e67db64e5b0f3cfc5ee # v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Lint platforms.yaml
         run: make lint-platforms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,12 @@ jobs:
 
   lint-platforms:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@2d2e96d11f9b3d2a35266e67db64e5b0f3cfc5ee # v6
 
       - name: Lint platforms.yaml
         run: make lint-platforms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
       - name: Lint overlays
         run: make lint-overlays
 
+  lint-platforms:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Lint platforms.yaml
+        run: make lint-platforms
+
   lint-go:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-embedded test clean lint lint-python lint-go lint-overlays
+.PHONY: build build-embedded test clean lint lint-python lint-go lint-overlays lint-platforms
 
 build:
 	$(MAKE) -C src/arch-query build
@@ -12,7 +12,7 @@ test:
 clean:
 	$(MAKE) -C src/arch-query clean
 
-lint: lint-python lint-go lint-overlays
+lint: lint-python lint-go lint-overlays lint-platforms
 
 lint-python:
 	uv run ruff check .
@@ -22,3 +22,6 @@ lint-go:
 
 lint-overlays:
 	uv run python scripts/lint_overlays.py
+
+lint-platforms:
+	uv run python scripts/lint_platforms.py

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -1,6 +1,7 @@
 """Phase 1: Fetch/clone repositories using gh-org-clone."""
 
 import asyncio
+import fnmatch
 import os
 import shutil
 from pathlib import Path
@@ -389,6 +390,22 @@ async def _clone_org(
     print(f"Successfully cloned repositories from {org}")
 
 
+def _apply_exclude_files(repo_path: Path, patterns: list, repo_name: str) -> None:
+    """Remove files/directories matching glob patterns from a cloned repo."""
+    for pattern in patterns:
+        matches = sorted(repo_path.glob(pattern))
+        if not matches:
+            continue
+        for match in matches:
+            rel = match.relative_to(repo_path)
+            if match.is_dir():
+                shutil.rmtree(match)
+                print(f"  exclude_files [{repo_name}]: removed directory {rel}/")
+            elif match.exists():
+                match.unlink()
+                print(f"  exclude_files [{repo_name}]: removed {rel}")
+
+
 async def _clone_repo(
     checkouts_dir: Path,
     org: str,
@@ -396,6 +413,7 @@ async def _clone_repo(
     branch: str = None,
     suffix: str = None,
     pull: bool = False,
+    exclude_files: list = None,
 ) -> None:
     """Clone an individual repository."""
     org_dir = f"{org}.{suffix}" if suffix else org
@@ -418,6 +436,8 @@ async def _clone_repo(
                     print(f"  {org}/{repo}: up to date")
                 else:
                     print(f"  {org}/{repo}: updated")
+                if exclude_files:
+                    _apply_exclude_files(repo_path, exclude_files, repo)
             else:
                 print(f"  {org}/{repo}: pull failed ({stderr.decode().strip()})")
         else:
@@ -450,6 +470,8 @@ async def _clone_repo(
             print(f"  Skipped {org}/{repo} (branch '{branch}' not found)")
         else:
             print(f"  Failed to clone {org}/{repo}")
+    elif exclude_files:
+        _apply_exclude_files(repo_path, exclude_files, repo)
 
 
 async def fetch_repositories(
@@ -534,7 +556,23 @@ async def fetch_repositories(
                 repo_branch = entry.get("branch")
                 repo_suffix = entry.get("suffix") or suffix
                 await _clone_repo(checkouts_path, entry["org"], entry["repo"],
-                                  branch=repo_branch, suffix=repo_suffix, pull=pull)
+                                  branch=repo_branch, suffix=repo_suffix, pull=pull,
+                                  exclude_files=entry.get("exclude_files"))
+
+        # Apply platform-wide post_checkout exclude_files rules
+        post_checkout = config.get("post_checkout", [])
+        if post_checkout:
+            for org_dir in sorted(checkouts_path.iterdir()):
+                if not org_dir.is_dir():
+                    continue
+                for repo_dir in sorted(org_dir.iterdir()):
+                    if not repo_dir.is_dir():
+                        continue
+                    for rule in post_checkout:
+                        if fnmatch.fnmatch(repo_dir.name, rule["repo"]):
+                            _apply_exclude_files(
+                                repo_dir, rule["exclude_files"], repo_dir.name,
+                            )
 
     elif org:
         # Direct org mode (original behavior)

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -392,11 +392,24 @@ async def _clone_org(
 
 def _apply_exclude_files(repo_path: Path, patterns: list, repo_name: str) -> None:
     """Remove files/directories matching glob patterns from a cloned repo."""
+    resolved_root = repo_path.resolve()
     for pattern in patterns:
+        if ".." in pattern or pattern.startswith("/"):
+            print(f"  exclude_files [{repo_name}]: REJECTED unsafe pattern: {pattern}")
+            continue
         matches = sorted(repo_path.glob(pattern))
         if not matches:
             continue
         for match in matches:
+            resolved = match.resolve()
+            if resolved != resolved_root and not str(resolved).startswith(
+                str(resolved_root) + os.sep
+            ):
+                print(
+                    f"  exclude_files [{repo_name}]:"
+                    f" SKIPPED {match} (escapes repo root)"
+                )
+                continue
             rel = match.relative_to(repo_path)
             if match.is_dir():
                 shutil.rmtree(match)
@@ -436,12 +449,12 @@ async def _clone_repo(
                     print(f"  {org}/{repo}: up to date")
                 else:
                     print(f"  {org}/{repo}: updated")
-                if exclude_files:
-                    _apply_exclude_files(repo_path, exclude_files, repo)
             else:
                 print(f"  {org}/{repo}: pull failed ({stderr.decode().strip()})")
         else:
             print(f"  Skipped {org}/{repo} (already exists)")
+        if exclude_files:
+            _apply_exclude_files(repo_path, exclude_files, repo)
         return
 
     clone_url = f"https://github.com/{org}/{repo}.git"
@@ -524,9 +537,13 @@ async def fetch_repositories(
             all_excludes.extend(exclude.split(","))
         exclude_str = ",".join(all_excludes) if all_excludes else None
 
+        platform_org_dirs = set()
+
         # Clone primary orgs (with branch + suffix)
         orgs = config.get("orgs", [])
         for cfg_org in orgs:
+            org_dir_name = f"{cfg_org}.{suffix}" if suffix else cfg_org
+            platform_org_dirs.add(org_dir_name)
             await _clone_org(gh_org_clone_cmd, cfg_org, checkouts_path,
                              branch=branch, suffix=suffix, exclude=exclude_str)
             if pull:
@@ -542,6 +559,8 @@ async def fetch_repositories(
                 if isinstance(entry, dict)
                 else None
             ) or suffix
+            org_dir_name = f"{org_name}.{org_suffix}" if org_suffix else org_name
+            platform_org_dirs.add(org_dir_name)
             await _clone_org(gh_org_clone_cmd, org_name, checkouts_path,
                              branch=org_branch, suffix=org_suffix, exclude=exclude_str)
             if pull:
@@ -555,6 +574,10 @@ async def fetch_repositories(
             for entry in extra_repos:
                 repo_branch = entry.get("branch")
                 repo_suffix = entry.get("suffix") or suffix
+                org_dir_name = (
+                    f"{entry['org']}.{repo_suffix}" if repo_suffix else entry["org"]
+                )
+                platform_org_dirs.add(org_dir_name)
                 await _clone_repo(checkouts_path, entry["org"], entry["repo"],
                                   branch=repo_branch, suffix=repo_suffix, pull=pull,
                                   exclude_files=entry.get("exclude_files"))
@@ -562,7 +585,14 @@ async def fetch_repositories(
         # Apply platform-wide post_checkout exclude_files rules
         post_checkout = config.get("post_checkout", [])
         if post_checkout:
-            for org_dir in sorted(checkouts_path.iterdir()):
+            for i, rule in enumerate(post_checkout):
+                if "repo" not in rule or "exclude_files" not in rule:
+                    raise ValueError(
+                        f"post_checkout[{i}]: each entry must have"
+                        " 'repo' and 'exclude_files' keys"
+                    )
+            for org_dir_name in sorted(platform_org_dirs):
+                org_dir = checkouts_path / org_dir_name
                 if not org_dir.is_dir():
                     continue
                 for repo_dir in sorted(org_dir.iterdir()):

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -392,6 +392,19 @@ async def _clone_org(
 
 def _apply_exclude_files(repo_path: Path, patterns: list, repo_name: str) -> None:
     """Remove files/directories matching glob patterns from a cloned repo."""
+    if repo_path.is_symlink():
+        raise ValueError(
+            f"exclude_files for {repo_name}: repo path is a symlink"
+        )
+    if not (repo_path / ".git").is_dir():
+        raise ValueError(
+            f"exclude_files for {repo_name}: not a git checkout"
+        )
+    if isinstance(patterns, str) or not isinstance(patterns, list):
+        raise ValueError(
+            f"exclude_files for {repo_name} must be a list of"
+            " glob patterns, not a bare string"
+        )
     resolved_root = repo_path.resolve()
     for pattern in patterns:
         if ".." in pattern or pattern.startswith("/"):

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -18,6 +18,13 @@
 ##   exclude_components   - remove components from the map (supports globs)
 ##   include_components   - add components not found by discovery
 ##
+## Post-checkout cleanup (remove sensitive files before architecture analysis):
+##   post_checkout         - platform-wide rules (list of {repo, exclude_files})
+##                           repo supports glob patterns via fnmatch
+##
+## Per extra_repos entry:
+##   exclude_files         - files/dirs to delete after cloning (list of glob patterns)
+##
 ## Use YAML anchors (&name / *name) to share config across entries.
 
 _rhoai_common: &rhoai_common
@@ -34,6 +41,10 @@ _rhoai_common: &rhoai_common
     - "*/test-infra"
   exclude_components:
     - opendatahub-operator
+  post_checkout:
+    - repo: models-perf-benchmark-data
+      exclude_files:
+        - "data/"
 
 odh:
   suffix: head

--- a/scripts/lint_platforms.py
+++ b/scripts/lint_platforms.py
@@ -100,6 +100,7 @@ def _check_extra_repos(value, errors):
             f" got {type(value).__name__}"
         )
         return
+    allowed = {"org", "repo", "branch", "suffix", "exclude_files"}
     for i, entry in enumerate(value):
         if not isinstance(entry, dict):
             errors.append(
@@ -107,6 +108,12 @@ def _check_extra_repos(value, errors):
                 f" got {type(entry).__name__}"
             )
             continue
+        unknown = set(entry.keys()) - allowed
+        if unknown:
+            errors.append(
+                f"'extra_repos[{i}]': unrecognized keys:"
+                f" {', '.join(sorted(unknown))}"
+            )
         for req in ("org", "repo"):
             if req not in entry:
                 errors.append(
@@ -247,8 +254,12 @@ def main() -> int:
         print(f"platforms.yaml not found: {PLATFORMS_FILE}")
         return 1
 
-    with open(PLATFORMS_FILE) as f:
-        data = yaml.safe_load(f)
+    try:
+        with open(PLATFORMS_FILE, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        print(f"invalid YAML in {PLATFORMS_FILE}: {e}")
+        return 1
 
     if not isinstance(data, dict):
         print("platforms.yaml root must be a YAML mapping")

--- a/scripts/lint_platforms.py
+++ b/scripts/lint_platforms.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Validate platforms.yaml schema and safety constraints."""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+PLATFORMS_FILE = Path(__file__).resolve().parent.parent / "platforms.yaml"
+
+KNOWN_KEYS = {
+    "suffix",
+    "branch",
+    "version",
+    "orgs",
+    "extra_orgs",
+    "extra_repos",
+    "exclude_repos",
+    "exclude_components",
+    "include_components",
+    "component_overrides",
+    "post_checkout",
+}
+
+
+def _check_str(value, label, errors):
+    if not isinstance(value, str):
+        errors.append(f"'{label}' must be a string, got {type(value).__name__}")
+
+
+def _check_list_of_str(value, label, errors):
+    if not isinstance(value, list):
+        errors.append(
+            f"'{label}' must be a list, got {type(value).__name__}"
+        )
+        return
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            errors.append(
+                f"'{label}[{i}]' must be a string,"
+                f" got {type(item).__name__}"
+            )
+
+
+def _check_exclude_patterns(patterns, label, errors):
+    if not isinstance(patterns, list):
+        errors.append(
+            f"'{label}' must be a list of glob patterns,"
+            f" got {type(patterns).__name__}"
+        )
+        return
+    for i, p in enumerate(patterns):
+        if not isinstance(p, str):
+            errors.append(
+                f"'{label}[{i}]' must be a string,"
+                f" got {type(p).__name__}"
+            )
+        elif ".." in p:
+            errors.append(
+                f"'{label}[{i}]': pattern contains '..'"
+                " (path traversal)"
+            )
+        elif p.startswith("/"):
+            errors.append(
+                f"'{label}[{i}]': pattern is an absolute path"
+            )
+
+
+def _check_extra_orgs(value, errors):
+    if not isinstance(value, list):
+        errors.append(
+            f"'extra_orgs' must be a list,"
+            f" got {type(value).__name__}"
+        )
+        return
+    for i, entry in enumerate(value):
+        if isinstance(entry, str):
+            continue
+        if not isinstance(entry, dict):
+            errors.append(
+                f"'extra_orgs[{i}]' must be a string or dict,"
+                f" got {type(entry).__name__}"
+            )
+            continue
+        if "org" not in entry:
+            errors.append(f"'extra_orgs[{i}]': missing required 'org'")
+        elif not isinstance(entry["org"], str):
+            errors.append(f"'extra_orgs[{i}].org' must be a string")
+        for k in ("branch", "suffix"):
+            if k in entry and not isinstance(entry[k], str):
+                errors.append(
+                    f"'extra_orgs[{i}].{k}' must be a string"
+                )
+
+
+def _check_extra_repos(value, errors):
+    if not isinstance(value, list):
+        errors.append(
+            f"'extra_repos' must be a list,"
+            f" got {type(value).__name__}"
+        )
+        return
+    for i, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            errors.append(
+                f"'extra_repos[{i}]' must be a dict,"
+                f" got {type(entry).__name__}"
+            )
+            continue
+        for req in ("org", "repo"):
+            if req not in entry:
+                errors.append(
+                    f"'extra_repos[{i}]': missing required '{req}'"
+                )
+            elif not isinstance(entry[req], str):
+                errors.append(
+                    f"'extra_repos[{i}].{req}' must be a string"
+                )
+        for opt in ("branch", "suffix"):
+            if opt in entry and not isinstance(entry[opt], str):
+                errors.append(
+                    f"'extra_repos[{i}].{opt}' must be a string"
+                )
+        if "exclude_files" in entry:
+            _check_exclude_patterns(
+                entry["exclude_files"],
+                f"extra_repos[{i}].exclude_files",
+                errors,
+            )
+
+
+def _check_include_components(value, errors):
+    if not isinstance(value, list):
+        errors.append(
+            f"'include_components' must be a list,"
+            f" got {type(value).__name__}"
+        )
+        return
+    for i, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            errors.append(
+                f"'include_components[{i}]' must be a dict,"
+                f" got {type(entry).__name__}"
+            )
+            continue
+        for req in ("key", "repo_org", "repo_name", "type"):
+            if req not in entry:
+                errors.append(
+                    f"'include_components[{i}]':"
+                    f" missing required '{req}'"
+                )
+            elif not isinstance(entry[req], str):
+                errors.append(
+                    f"'include_components[{i}].{req}'"
+                    " must be a string"
+                )
+
+
+def _check_post_checkout(value, errors):
+    if not isinstance(value, list):
+        errors.append(
+            f"'post_checkout' must be a list,"
+            f" got {type(value).__name__}"
+        )
+        return
+    for i, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            errors.append(
+                f"'post_checkout[{i}]' must be a dict,"
+                f" got {type(entry).__name__}"
+            )
+            continue
+        if "repo" not in entry:
+            errors.append(
+                f"'post_checkout[{i}]': missing required 'repo'"
+            )
+        elif not isinstance(entry["repo"], str):
+            errors.append(
+                f"'post_checkout[{i}].repo' must be a string"
+            )
+        if "exclude_files" not in entry:
+            errors.append(
+                f"'post_checkout[{i}]':"
+                " missing required 'exclude_files'"
+            )
+        else:
+            _check_exclude_patterns(
+                entry["exclude_files"],
+                f"post_checkout[{i}].exclude_files",
+                errors,
+            )
+
+
+def validate_platform(name: str, config: dict) -> list[str]:
+    errors: list[str] = []
+
+    if not isinstance(config, dict):
+        errors.append("platform value must be a mapping")
+        return errors
+
+    unknown = set(config.keys()) - KNOWN_KEYS
+    if unknown:
+        errors.append(
+            f"unrecognized keys: {', '.join(sorted(unknown))}"
+        )
+
+    for key in ("suffix", "branch", "version"):
+        if key in config:
+            _check_str(config[key], key, errors)
+
+    for key in ("orgs", "exclude_repos", "exclude_components"):
+        if key in config:
+            _check_list_of_str(config[key], key, errors)
+
+    if "extra_orgs" in config:
+        _check_extra_orgs(config["extra_orgs"], errors)
+
+    if "extra_repos" in config:
+        _check_extra_repos(config["extra_repos"], errors)
+
+    if "include_components" in config:
+        _check_include_components(config["include_components"], errors)
+
+    if "component_overrides" in config:
+        co = config["component_overrides"]
+        if not isinstance(co, dict):
+            errors.append(
+                "'component_overrides' must be a mapping,"
+                f" got {type(co).__name__}"
+            )
+        else:
+            for k, v in co.items():
+                if not isinstance(v, dict):
+                    errors.append(
+                        f"'component_overrides.{k}'"
+                        " must be a mapping"
+                    )
+
+    if "post_checkout" in config:
+        _check_post_checkout(config["post_checkout"], errors)
+
+    return errors
+
+
+def main() -> int:
+    if not PLATFORMS_FILE.exists():
+        print(f"platforms.yaml not found: {PLATFORMS_FILE}")
+        return 1
+
+    with open(PLATFORMS_FILE) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        print("platforms.yaml root must be a YAML mapping")
+        return 1
+
+    total_errors = 0
+    platforms = sorted(
+        k for k in data if not k.startswith("_")
+    )
+
+    for name in platforms:
+        errors = validate_platform(name, data[name])
+        if errors:
+            print(f"{name}:")
+            for e in errors:
+                print(f"  - {e}")
+            total_errors += len(errors)
+
+    if total_errors:
+        print(
+            f"\n{total_errors} error(s) in"
+            f" {len(platforms)} platform(s)"
+        )
+        return 1
+
+    print(
+        f"All {len(platforms)} platform(s) passed validation."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a declarative `exclude_files` mechanism to remove sensitive files/dirs from cloned repos before the architecture skill reads them
- Supports two levels: per-`extra_repos` entry (`exclude_files` key) and platform-wide rules (`post_checkout` with fnmatch repo matching)
- Configures `models-perf-benchmark-data` to have its `data/` directory removed after clone — this repo contains confidential benchmark data that must not leak into public architecture docs
- Uses `pathlib.glob` for file patterns and `shutil.rmtree`/`os.remove` for deletion — no arbitrary shell command execution

## Test plan

- [ ] Run `uv run ruff check lib/fetch.py` — passes
- [ ] Run fetch for an rhoai platform with `models-perf-benchmark-data` cloned and verify `data/` is removed
- [ ] Verify glob patterns work (e.g., `*.bin`)
- [ ] Verify exclusions run after pull (`--pull`) but not when repo is skipped (already exists, no pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repo checkouts can exclude files or directories using glob patterns.
  * Platform-wide post-checkout cleanup rules added, with per-repo overrides.

* **Bug Fixes / Validation**
  * Safety checks reject unsafe exclude patterns (no path traversal or absolute paths) and prevent escapes.
  * Post-checkout entries are validated for required keys and types.

* **Chores**
  * Added platforms linting job and Makefile target; included a platforms YAML linter script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->