### PR TITLE
Add Project Navigator (rhoai-mcp + llm-d-planner) to architecture context

### DIFF
--- a/overlays/0010-project-navigator-naming.md
+++ b/overlays/0010-project-navigator-naming.md
@@ -33,7 +33,7 @@ The feature consists of two repositories:
 | rhoai-mcp | opendatahub-io | Frontend — MCP (Model Context Protocol) server for RHOAI |
 | llm-d-planner | llm-d-incubation | Backend — planning and orchestration engine |
 
-Neither repository has RHOAI release branches; both are cloned from `main` via `extra_repos`. The feature entered Developer Preview in RHOAI 3.4 and is planned for Tech Preview in 3.5.
+Neither repository has RHOAI release branches; both are cloned from `main` via `extra_repos`. The feature entered Developer Preview in RHOAI 3.4, is planned for Tech Preview in 3.5, and should be treated as Tech Preview for `next` unless superseded by a later overlay.
 
 ## Impact on Strategies
 

--- a/overlays/0010-project-navigator-naming.md
+++ b/overlays/0010-project-navigator-naming.md
@@ -8,7 +8,9 @@ affects:
   - llm-d-planner
 release:
   - "3.4"
+  - "3.4-ea.2"
   - "3.5"
+  - "3.5-ea.1"
   - "next"
 provenance:
   - https://issues.redhat.com/browse/RHAIFIRST-23

--- a/overlays/0010-project-navigator-naming.md
+++ b/overlays/0010-project-navigator-naming.md
@@ -1,0 +1,46 @@
+---
+id: "0010"
+title: Project Navigator naming history and repo mapping
+status: active
+created: 2026-05-14
+affects:
+  - rhoai-mcp
+  - llm-d-planner
+release:
+  - "3.4"
+  - "3.5"
+  - "next"
+provenance:
+  - https://issues.redhat.com/browse/RHAIFIRST-23
+author: James Tanner
+superseded_by: null
+---
+
+## Fact
+
+"Project Navigator" is a feature that has used several names during development:
+
+| Name | Context |
+|------|---------|
+| NeuralNav | Original internal codename (still referenced in codebase) |
+| Project Navigator | Jira component name and stakeholder-facing name |
+| llm-d planner | Current product direction name |
+
+The feature consists of two repositories:
+
+| Repo | Org | Role |
+|------|-----|------|
+| rhoai-mcp | opendatahub-io | Frontend — MCP (Model Context Protocol) server for RHOAI |
+| llm-d-planner | llm-d-incubation | Backend — planning and orchestration engine |
+
+Neither repository has RHOAI release branches; both are cloned from `main` via `extra_repos`. The feature entered Developer Preview in RHOAI 3.4 and is planned for Tech Preview in 3.5.
+
+## Impact on Strategies
+
+- All three names (NeuralNav, Project Navigator, llm-d planner) refer to the same feature — strategies should use **Project Navigator** as the primary name with "(also known as llm-d planner)" on first mention
+- Architecture context for this feature is split across two repos; strategies should consider `rhoai-mcp` and `llm-d-planner` together as a single logical feature
+- The feature is DP in 3.4 and planned TP in 3.5 — strategies should reflect the appropriate maturity level for each release
+
+## Context
+
+The rfe-creator bot could not find "Project Navigator" in the platform inventory because the component discovery pipeline indexes by repository name (`rhoai-mcp`, `llm-d-planner`), not by marketing or codename. This overlay bridges the naming gap so that queries using any of the three names can locate the correct architecture context.

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -90,8 +90,10 @@ rhoai.next:
       repo: training_hub
     - org: opendatahub-io
       repo: rhoai-mcp
+      branch: main
     - org: llm-d-incubation
       repo: llm-d-planner
+      branch: main
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -128,8 +130,10 @@ rhoai-3.5-ea.1:
       repo: training_hub
     - org: opendatahub-io
       repo: rhoai-mcp
+      branch: main
     - org: llm-d-incubation
       repo: llm-d-planner
+      branch: main
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -166,8 +170,10 @@ rhoai-3.4:
       repo: training_hub
     - org: opendatahub-io
       repo: rhoai-mcp
+      branch: main
     - org: llm-d-incubation
       repo: llm-d-planner
+      branch: main
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -204,8 +210,10 @@ rhoai-3.4-ea.2:
       repo: training_hub
     - org: opendatahub-io
       repo: rhoai-mcp
+      branch: main
     - org: llm-d-incubation
       repo: llm-d-planner
+      branch: main
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -88,6 +88,10 @@ rhoai.next:
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
       repo: training_hub
+    - org: opendatahub-io
+      repo: rhoai-mcp
+    - org: llm-d-incubation
+      repo: llm-d-planner
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -102,6 +106,14 @@ rhoai.next:
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
       type: library
+    - key: rhoai-mcp
+      repo_org: opendatahub-io
+      repo_name: rhoai-mcp
+      type: service
+    - key: llm-d-planner
+      repo_org: llm-d-incubation
+      repo_name: llm-d-planner
+      type: service
 
 rhoai-3.5-ea.1:
   <<: *rhoai_3x_common
@@ -114,6 +126,10 @@ rhoai-3.5-ea.1:
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
       repo: training_hub
+    - org: opendatahub-io
+      repo: rhoai-mcp
+    - org: llm-d-incubation
+      repo: llm-d-planner
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -128,6 +144,14 @@ rhoai-3.5-ea.1:
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
       type: library
+    - key: rhoai-mcp
+      repo_org: opendatahub-io
+      repo_name: rhoai-mcp
+      type: service
+    - key: llm-d-planner
+      repo_org: llm-d-incubation
+      repo_name: llm-d-planner
+      type: service
 
 rhoai-3.4:
   <<: *rhoai_3x_common
@@ -140,6 +164,10 @@ rhoai-3.4:
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
       repo: training_hub
+    - org: opendatahub-io
+      repo: rhoai-mcp
+    - org: llm-d-incubation
+      repo: llm-d-planner
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -154,6 +182,14 @@ rhoai-3.4:
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
       type: library
+    - key: rhoai-mcp
+      repo_org: opendatahub-io
+      repo_name: rhoai-mcp
+      type: service
+    - key: llm-d-planner
+      repo_org: llm-d-incubation
+      repo_name: llm-d-planner
+      type: service
 
 rhoai-3.4-ea.2:
   <<: *rhoai_3x_common
@@ -166,6 +202,10 @@ rhoai-3.4-ea.2:
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
       repo: training_hub
+    - org: opendatahub-io
+      repo: rhoai-mcp
+    - org: llm-d-incubation
+      repo: llm-d-planner
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -180,6 +220,14 @@ rhoai-3.4-ea.2:
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
       type: library
+    - key: rhoai-mcp
+      repo_org: opendatahub-io
+      repo_name: rhoai-mcp
+      type: service
+    - key: llm-d-planner
+      repo_org: llm-d-incubation
+      repo_name: llm-d-planner
+      type: service
 
 rhoai-3.4-ea.1:
   <<: *rhoai_3x_common


### PR DESCRIPTION
## Summary

- Adds `opendatahub-io/rhoai-mcp` (frontend MCP server) and `llm-d-incubation/llm-d-planner` (backend planner) as `extra_repos` and `include_components` (type: service) for platforms: rhoai.next, rhoai-3.5-ea.1, rhoai-3.4, rhoai-3.4-ea.2
- Creates overlay 0010 documenting the naming history (NeuralNav → Project Navigator → llm-d planner) and mapping to the actual repositories
- Neither repo has RHOAI release branches — they clone `main` via `extra_repos` (platform branch only affects `gh-org-clone` for primary orgs)

Resolves: RHAIFIRST-23

## Test plan

- [x] `make lint` passes (platforms, overlays, ruff, golangci-lint)
- [ ] `uv run python main.py fetch --platform=rhoai.next` clones both repos
- [ ] Component discovery finds both in component-map.json
- [ ] Architecture generation produces summaries for rhoai-mcp and llm-d-planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an overlay documenting Project Navigator naming history, mapping multiple development names to the same product context, noting affected components and provenance, and specifying intended maturity (Developer Preview in 3.4; Tech Preview planned for 3.5). Addresses discovery gaps so queries using any name resolve correctly.

* **Chores**
  * Updated platform configurations to include Project Navigator services across targeted preview and release tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->