### PR TITLE
add Kubeflow SDK overlay and platforms.yaml integration

### DIFF
--- a/overlays/0012-kubeflow-sdk-platform-integration.md
+++ b/overlays/0012-kubeflow-sdk-platform-integration.md
@@ -1,0 +1,86 @@
+---
+id: "0012"
+title: Kubeflow SDK platform integration and midstream architecture context
+status: active
+created: 2026-05-26
+affects:
+  - platform
+  - notebooks
+  - trainer
+  - training-operator
+release:
+  - "3.4"
+  - "3.5"
+  - "next"
+provenance:
+  - https://redhat.atlassian.net/browse/RHOAIENG-62211
+  - https://github.com/opendatahub-io/kubeflow-sdk
+  - https://github.com/kubeflow/sdk
+author: Brian Gallagher
+superseded_by: null
+---
+
+## Fact
+
+The **Kubeflow SDK** (`opendatahub-io/kubeflow-sdk`) is a shipped RHOAI component providing the unified Python API (`kubeflow` package) for Kubeflow Trainer, Optimizer, Spark Operator, and Model Registry. It is distributed as a pip dependency inside universal training images (via `distributed-workloads`) and notebook workbench images. The SDK is absent from the architecture-context component inventory and has no generated architecture doc because: (a) the repo lives in `opendatahub-io`, not `red-hat-data-services`, (b) it has no operator manifest entry, and (c) it is not listed in `platforms.yaml` `extra_repos`.
+
+The SDK has a three-tier delivery flow:
+
+| Tier | Repo | Versioning |
+|------|------|-----------|
+| Upstream | `kubeflow/sdk` | Semantic (`0.4.0`) |
+| Midstream (ODH) | `opendatahub-io/kubeflow-sdk` | RHAI (`v0.3.0+rhaiv.2`) |
+| Downstream | AIPCC indexes (no separate repo) | Same as midstream |
+
+Current shipped version: **v0.3.0+rhaiv.2** (RHOAI 3.4 GA). Upstream is at **0.4.0**.
+
+### Sub-packages and Platform Relationships
+
+| Sub-package | Platform Component | Interaction |
+|-------------|-------------------|-------------|
+| `kubeflow.trainer` | Trainer / Training Operator | Creates TrainJob and ClusterTrainingRuntime CRs via Kubernetes API |
+| `kubeflow.optimizer` | (upstream only, not yet shipped in RHOAI) | Creates Experiment CRs for hyperparameter optimization |
+| `kubeflow.hub` | Model Registry | REST API client for model registration and versioning |
+| `kubeflow.spark` | Spark Operator | Creates SparkConnect sessions via Kubernetes API |
+
+### Midstream Divergence
+
+The midstream fork carries RHOAI-specific extensions not present upstream:
+
+| Path | Purpose |
+|------|---------|
+| `kubeflow/trainer/rhai/` | TrainingHub/RHAI trainer extensions (checkpoints, S3, LoRA, algorithms) |
+| `kubeflow/trainer/algorithms.py` | Centralized training algorithm registry (SFT, OSFT, LoRA, GRPO) |
+| `.github/workflows/odh-release.yaml` | Midstream release workflow |
+| `.github/workflows/rebase-upstream.yaml` | Daily upstream sync (merge-based) |
+
+These extensions exist because RHOAI ships Training Hub (a higher-level training abstraction) integrated into the SDK's trainer sub-package, whereas upstream Trainer uses the lower-level Kubeflow Training API directly. The divergence is intentional and maintained -- it will either graduate upstream or remain as a permanent midstream extension depending on Training Hub's upstream adoption trajectory.
+
+### Upstream Sync
+
+The midstream syncs with upstream daily via GitHub Actions (`rebase-upstream.yaml`). Conflicts are common in `pyproject.toml` (dependency groups), `kubeflow/__init__.py` (version string), and `kubeflow/trainer/backends/` (both sides modify). A Cursor skill (`team-kubeflow-devx` repo: `skills/upstream-sync-resolver/`) provides tiered automated conflict resolution.
+
+### Release Cadence
+
+The SDK is cut **10 days before each RHOAI code freeze**. Component teams (Trainer, Model Registry, Spark) own their sub-packages; the Kubeflow DevX team cuts releases and manages interoperability.
+
+### Contacts
+
+| Channel | Purpose |
+|---------|---------|
+| `#forum-openshift-ai-kubeflow-sdk` (Slack) | SDK development and releases |
+| `@openshift-ai-kubeflow-devx` (Slack) | Team handle |
+| `#kubeflow-ml-experience` (CNCF Slack) | Upstream ML Experience WG |
+
+## Impact on Strategies
+
+- Treat **kubeflow SDK** as a shipped RHOAI component, functionally equivalent to CodeFlare SDK in delivery pattern (pip dependency in workbench/universal images, no operator manifest)
+- The SDK is the **developer entry point** for training, optimization, model registry, and Spark. RFEs targeting user-facing training workflows should trace through the SDK API, not just the operator CRDs
+- The midstream carries Training Hub extensions (`kubeflow/trainer/rhai/`). Architecture reviewers should not flag these as "upstream divergence risk" without context -- the divergence is intentional and actively managed via daily sync
+- The SDK version lags upstream by one minor version in RHOAI GA (currently `0.3.0+rhaiv.2` vs upstream `0.4.0`). Strategies requiring upstream `0.4.0` features (SparkClient, RuntimePatches API) should target RHOAI 3.5+
+- `kubeflow.pipelines` (KFP integration) is planned but not yet available. Strategies requiring both Pipelines and Training SDK access must still use `kfp` alongside `kubeflow` as separate packages
+- Component teams own their sub-packages but do **not** cut SDK releases. Dependency changes or new optional extras require AIPCC onboarding coordination with the SDK team
+
+## Context
+
+The architecture generation pipeline discovers components via org clone + manifest parsing + adjacent repo scanning. The Kubeflow SDK is not discoverable because: it lives in `opendatahub-io` (not in the `red-hat-data-services` org clone used for RHOAI), it has no Kubernetes manifests, and it ships as a transitive pip dependency rather than a container image. This is the same pattern as CodeFlare SDK (overlay 0004), which was resolved by adding it to `platforms.yaml` as an `extra_repos` entry. This overlay is accompanied by a `platforms.yaml` change to enable full architecture generation in the next pipeline cycle.

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -51,6 +51,8 @@ _rhoai_3x_common: &rhoai_3x_common
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -77,6 +79,10 @@ odh:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
 
 rhoai.next:
   <<: *rhoai_3x_common
@@ -84,6 +90,8 @@ rhoai.next:
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
@@ -104,6 +112,10 @@ rhoai.next:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
     - key: training-hub
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
@@ -124,6 +136,8 @@ rhoai-3.5-ea.1:
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
@@ -144,6 +158,10 @@ rhoai-3.5-ea.1:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
     - key: training-hub
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
@@ -164,6 +182,8 @@ rhoai-3.4:
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
@@ -184,6 +204,10 @@ rhoai-3.4:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
     - key: training-hub
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
@@ -204,6 +228,8 @@ rhoai-3.4-ea.2:
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
@@ -224,6 +250,10 @@ rhoai-3.4-ea.2:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
     - key: training-hub
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub
@@ -244,6 +274,8 @@ rhoai-3.4-ea.1:
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
     - org: red-hat-data-services
@@ -256,6 +288,10 @@ rhoai-3.4-ea.1:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
 
 rhoai-3.3:
   <<: *rhoai_3x_common


### PR DESCRIPTION
## Summary

- Adds overlay `0012-kubeflow-sdk-platform-integration.md` documenting the Kubeflow SDK (`opendatahub-io/kubeflow-sdk`) as a shipped RHOAI component with cross-component integration context
- Adds `opendatahub-io/kubeflow-sdk` to `platforms.yaml` `extra_repos` and `include_components` for all RHOAI 3.x platforms, enabling full architecture doc generation on the next pipeline cycle

The overlay captures strategic/organisational context that a generated architecture doc cannot derive from source code alone:
- Three-tier delivery flow (upstream to midstream to AIPCC)
- Midstream divergence rationale (Training Hub extensions in `kubeflow/trainer/rhai/`)
- Upstream sync process and conflict patterns
- Release cadence relationship to RHOAI code freeze
- Component team responsibility split
- Relevant Slack channels

The `platforms.yaml` change follows the same pattern used for CodeFlare SDK (`project-codeflare/codeflare-sdk`).

## Test plan

- [x] `scripts/lint_overlays.py` passes (13 overlays validated)
- [x] `platforms.yaml` parses as valid YAML
- [ ] Next pipeline run for `rhoai.next` discovers and generates `kubeflow-sdk.md`

Ref: [RHOAIENG-62211](https://redhat.atlassian.net/browse/RHOAIENG-62211)
