### PR TITLE
overlay: add Model Runtimes team architecture (0014-0016)

### DIFF
--- a/overlays/0014-model-runtimes-team-architecture.md
+++ b/overlays/0014-model-runtimes-team-architecture.md
@@ -382,7 +382,8 @@ Source: `odh-model-controller/config/runtimes/vllm-*.yaml` (all declare REST); P
 - **Template**: None — not in `odh-model-controller/config/runtimes/`; test creates ServingRuntime CRD directly
 - **Image**: `nvcr.io/nvidia/tritonserver:25.02-py3` (from NVIDIA GPU Cloud, not `registry.redhat.io`)
   - Version 25.02 is pinned as the **last release** with TensorFlow backend included
-  - TensorFlow backend deprecated in 25.03, completely removed in 26.x+
+  - TensorFlow backend deprecated and removed starting with 25.03 (v2.56.0)
+  - The 25.02 pin is deliberate: the current test matrix requires the TensorFlow backend. No CVE support applies — Triton is not shipped with RHOAI (`registry.redhat.io` / CSV `relatedImages`); the image is sourced directly from NVIDIA (`nvcr.io`) for T&V validation only. Red Hat supports the deployment and integration layer (custom runtime via KServe), not the vendor image itself
   - Image version managed in `tests/model_serving/model_runtime/triton/constant.py`
 - **Supported formats**: TensorRT, TensorFlow 1/2, ONNX, PyTorch (LibTorch), Triton (ensemble), XGBoost, Python, FIL (Forest Inference Library), DALI (GPU data pipeline), Keras
 - **Protocols**: REST (port 8080, v2 inference) + gRPC (port 9000, KServe Predict V2)
@@ -598,7 +599,7 @@ Source: `utilities/serving_runtime.py`, `utilities/inference_utils.py`, `tests/m
 - Triton support is bounded by the 7x2 validation matrix (7 formats, 2 protocols)
 - Features outside this matrix (dynamic batching, BLS, custom backends, model ensembles beyond tested patterns)
   are NOT part of the Tested & Verified designation
-- TensorFlow backend has limited shelf life (deprecated 25.03, removed 26.x+)
+- TensorFlow backend has limited shelf life (deprecated and removed from 25.03 onward) — the 25.02 pin is a deliberate test-matrix constraint, not a platform shipping decision. No CVE tracking applies to the NVIDIA-managed vendor image
 
 ### Testing Modernization (Source: PRs #1667, #1713, #1704, #1720)
 

--- a/overlays/0014-model-runtimes-team-architecture.md
+++ b/overlays/0014-model-runtimes-team-architecture.md
@@ -1,0 +1,627 @@
+---
+id: "0014"
+title: Model Runtimes team architecture — ownership, runtime lifecycle, and testing patterns
+status: active
+created: 2026-06-13
+affects:
+  - openvino_model_server
+  - MLServer
+  - vllm
+  - odh-model-controller
+  - kserve
+  - opendatahub-tests
+release:
+  - "3.4"
+  - "3.5"
+  - "next"
+provenance:
+  - https://github.com/opendatahub-io/opendatahub-tests/tree/main/tests/model_serving/model_runtime
+  - https://github.com/opendatahub-io/odh-model-controller/tree/main/config/runtimes
+  - https://github.com/opendatahub-io/odh-model-controller/blob/main/architecture.md
+  - https://github.com/opendatahub-io/kserve
+  - https://github.com/opendatahub-io/opendatahub-tests/blob/main/conftest.py
+  - https://github.com/opendatahub-io/opendatahub-tests/blob/main/utilities/inference_utils.py
+  - https://github.com/opendatahub-io/opendatahub-tests/blob/main/utilities/serving_runtime.py
+  - https://github.com/opendatahub-io/opendatahub-tests/blob/main/utilities/constants.py
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1667
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1679
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1704
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1713
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1720
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1723
+  - https://github.com/opendatahub-io/MLServer
+  - https://github.com/opendatahub-io/openvino_model_server
+  - https://github.com/SeldonIO/MLServer (orphaned upstream)
+author: Imran Khalidi, Model Runtimes Team
+superseded_by: null
+---
+
+## Fact
+
+### KServe Integration
+
+KServe provides the core model serving primitives for RHOAI. The platform uses the `opendatahub-io/kserve` fork
+(not upstream `kserve/kserve`). Key CRDs defined in `pkg/apis/serving/`:
+
+| CRD | API Version | Purpose | Scope |
+|-----|-------------|---------|-------|
+| `ServingRuntime` | `serving.kserve.io/v1alpha1` | Defines container image, supported model formats, protocol versions, resources | Namespace |
+| `ClusterServingRuntime` | `serving.kserve.io/v1alpha1` | Cluster-wide runtime definitions (platform-managed) | Cluster |
+| `InferenceService` | `serving.kserve.io/v1beta1` | References a ServingRuntime; adds storage URI, model format, resources, replicas | Namespace |
+| `InferenceGraph` | `serving.kserve.io/v1alpha1` | Multi-model routing DAG (stub reconciliation in ODH Model Controller) | Namespace |
+| `LLMInferenceService` | `serving.kserve.io/v1alpha2` | Purpose-built for LLM deployments with llm-d integration | Namespace |
+
+RHOAI exclusively uses **RawDeployment** mode (not Knative/Serverless). This means:
+- No Knative Serving dependency (`serverless-operator` not required)
+- KServe controller creates standard Kubernetes Deployments and Services directly
+- ODH Model Controller handles OpenShift Route creation (Knative Routes are not used)
+- `KServeDeploymentType.RAW_DEPLOYMENT` is the only mode used in test fixtures
+
+Source: `utilities/constants.py` defines `KServeDeploymentType` enum; `odh-model-controller/architecture.md`
+documents the RawDeployment-exclusive design decision.
+
+### KServe + ODH Model Controller Layering
+
+```
++------------------------------------------------------------------+
+|                        User / Dashboard                           |
+|   Creates InferenceService + selects ServingRuntime template      |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                     KServe Controller                             |
+|   (opendatahub-io/kserve)                                        |
+|                                                                  |
+|   Reconciles InferenceService into:                              |
+|   - Deployment (predictor pod with runtime container)            |
+|   - Service (ClusterIP, ports from SR spec)                      |
+|   - Validates: name length, namespace protection                 |
+|   - Injects: storage initializer (for S3/PVC/OCI sources)       |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                   ODH Model Controller                            |
+|   (opendatahub-io/odh-model-controller)                          |
+|                                                                  |
+|   Layers RHOAI-specific capabilities:                            |
+|   - OpenShift Routes (TLS passthrough, edge termination)         |
+|   - ServiceMonitors + PodMonitors (Prometheus scraping)          |
+|   - CA bundle aggregation (trusted certificates injection)       |
+|   - KEDA TriggerAuthentication (HPA/autoscaling)                 |
+|   - NIM account lifecycle (NVIDIA NIM integration)               |
+|   - Model Registry sync (model metadata propagation)             |
+|   - ServingRuntime template management                           |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                      Runtime Container                            |
+|   (vLLM | OVMS | MLServer | Triton)                             |
+|                                                                  |
+|   Runs inference, exposes REST/gRPC endpoints                    |
+|   HardwareProfile webhook injects GPU resource limits            |
++------------------------------------------------------------------+
+```
+
+Source: `odh-model-controller/architecture.md` full architecture description;
+`odh-model-controller/controllers/` for controller implementations.
+
+### Component Ownership Map
+
+```
++-----------------------------------------------------------------------+
+|                         Model Runtimes Team                            |
+|                                                                       |
+|  +---------------------+  +---------------------+  +---------------+  |
+|  | opendatahub-io/     |  | opendatahub-io/     |  | Runtime       |  |
+|  | openvino_model_     |  | MLServer            |  | template YAML |  |
+|  | server              |  | (carries AMD/ONNX)  |  | definitions   |  |
+|  +---------------------+  +---------------------+  +---------------+  |
+|                                                                       |
+|  +---------------------+                                              |
+|  | opendatahub-tests/  |                                              |
+|  | model_runtime/      |                                              |
+|  | (ALL runtime tests) |                                              |
+|  +---------------------+                                              |
++-----------------------------------------------------------------------+
+
++-----------------------------------------------------------------------+
+|                            RHAII Team                                  |
+|                                                                       |
+|  +---------------------------+  +----------------------------------+  |
+|  | vLLM Engine Builds        |  | Engine Feature Testing           |  |
+|  | (CUDA, ROCm, Gaudi)       |  | (multimodal, quant, spec-decode, |  |
+|  | registry.redhat.io        |  |  tool calling, TGIS, perf)       |  |
+|  +---------------------------+  +----------------------------------+  |
++-----------------------------------------------------------------------+
+
++-----------------------------------------------------------------------+
+|                       IBM Teams (separate forks)                       |
+|                                                                       |
+|  +---------------------------+  +----------------------------------+  |
+|  | red-hat-data-services/    |  | red-hat-data-services/           |  |
+|  | vllm-cpu                  |  | vllm-spyre                       |  |
+|  | (x86, Power ppc64le,      |  | (IBM Spyre accelerator)          |  |
+|  |  Z s390x builds)          |  |                                  |  |
+|  +---------------------------+  +----------------------------------+  |
+|                                                                       |
+|  IBM Power team: ppc64le arch (VSX kernels)                           |
+|  IBM Z team: s390x arch (VXE kernels)                                 |
+|  IBM Spyre team: Spyre accelerator integration                        |
++-----------------------------------------------------------------------+
+
++-----------------------------------------------------------------------+
+|                       Platform / KServe Team                           |
+|                                                                       |
+|  +---------------------+  +---------------------+  +---------------+  |
+|  | opendatahub-io/     |  | odh-model-controller|  | model_server/ |  |
+|  | kserve (CRDs,       |  | (companion ctrler:  |  | kserve/ tests |  |
+|  |  controllers,       |  |  Routes, monitoring,|  | (routes, auth |  |
+|  |  webhooks)          |  |  auth, NIM, KEDA)   |  |  scaling)     |  |
+|  +---------------------+  +---------------------+  +---------------+  |
++-----------------------------------------------------------------------+
+
++-----------------------------------------------------------------------+
+|                            NVIDIA                                      |
+|                                                                       |
+|  +----------------------------------+                                 |
+|  | nvcr.io/nvidia/tritonserver      |                                 |
+|  | (vendor image, not Red Hat built) |                                 |
+|  +----------------------------------+                                 |
++-----------------------------------------------------------------------+
+```
+
+### Runtime Deployment Paths
+
+```
+OUT-OF-THE-BOX PATH (OVMS, MLServer, vLLM):
+============================================
+
+  config/runtimes/*.yaml       Annotation-driven discovery:
+  (kustomized into operator)   opendatahub.io/dashboard: "true"
+         |                     opendatahub.io/ootb: "true"
+         v
+  +------------------+
+  | OpenShift        |     applications_namespace (e.g., redhat-ods-applications)
+  | Template         |     Dashboard reads templates from this namespace
+  +------------------+
+         |
+         | ServingRuntimeFromTemplate (per user namespace)
+         v
+  +------------------+
+  | ServingRuntime   |     Namespace-scoped, owned by user
+  | (from template)  |     Image: registry.redhat.io (sha256 digest)
+  +------------------+
+         |
+         | User creates InferenceService referencing this runtime
+         v
+  +------------------+
+  | InferenceService |     storage_uri, model_format, resources, replicas
+  +------------------+     external_route: true (for route creation)
+         |
+         | KServe Controller reconciles
+         v
+  +------------------+
+  | Deployment +     |     Predictor pod with runtime container
+  | Service          |     Storage initializer sidecar
+  +------------------+
+         |
+         | ODH Model Controller augments
+         v
+  +------------------+
+  | Route +          |     TLS passthrough route
+  | ServiceMonitor + |     Prometheus scrape target
+  | CA Bundle        |     Trusted CA injection
+  +------------------+
+
+
+TESTED & VERIFIED PATH (Triton):
+=================================
+
+  Test creates ServingRuntime CRD directly (no platform template)
+  Image: nvcr.io/nvidia/tritonserver (vendor registry)
+         |
+         v
+  +------------------+
+  | ServingRuntime   |     Created by test fixture (not from template)
+  | (custom CRD)    |     Defines: formats, ports, args, volumes
+  +------------------+
+         |
+         | InferenceService references runtime
+         v
+  +------------------+         +------------------+         +------------------+
+  | InferenceService | ------> | Deployment +     | ------> | Route +          |
+  |                  |  KServe | Service          |  ODH MC | ServiceMonitor   |
+  +------------------+         +------------------+         +------------------+
+```
+
+### HardwareProfile Mechanism
+
+HardwareProfiles abstract GPU resource allocation from users. When an InferenceService is created:
+1. User selects a HardwareProfile (e.g., "NVIDIA A100 40GB")
+2. The `rhods-operator` admission webhook intercepts the ISVC creation
+3. Webhook injects the appropriate resource limits (`nvidia.com/gpu: 1`) into the predictor container spec
+4. Neither the user nor the Dashboard needs to know the raw resource identifier
+
+This means new runtime templates do NOT need to hardcode GPU resources — the HardwareProfile webhook
+handles injection automatically. Templates only need the annotation:
+`opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'`
+
+Source: `rhods-operator` webhook; Dashboard HardwareProfile API.
+
+### Runtime Categories (Three-Tier Taxonomy)
+
+RHOAI defines three categories of model serving runtimes:
+
+| Category | Shipped in RHOAI | Support Level | Image Source | Template Location | Image Validation |
+|----------|-----------------|---------------|--------------|-------------------|-----------------|
+| **Out-of-the-box Supported** | Yes (CSV `relatedImages`) | Full Red Hat support | `registry.redhat.io` (sha256 digest) | `odh-model-controller/config/runtimes/` | Yes — `image_validation/` tests verify digests |
+| **Custom Runtimes** | No | No specific support | User-provided | User creates ServingRuntime CRD | No |
+| **Tested & Verified** | No | Limited to defined validation scope | Vendor registry (e.g., `nvcr.io`) | Test creates ServingRuntime CRD | No (vendor-managed) |
+
+The image validation tests (`tests/model_serving/model_runtime/image_validation/`) verify that out-of-the-box
+runtime images match expected sha256 digests from `registry.redhat.io`. The `RUNTIME_CONFIGS` list in
+`constant.py` only contains OVMS, MLServer, and vLLM — confirming Triton is NOT platform-shipped.
+
+Source: `tests/model_serving/model_runtime/image_validation/constant.py`
+
+### Ownership Boundaries
+
+| Component / Repo | Owner | Responsibility | Source |
+|-----------------|-------|----------------|--------|
+| `opendatahub-io/openvino_model_server` | Model Runtimes | OVMS midstream fork, container image, Intel GPU support | GitHub repo |
+| `opendatahub-io/MLServer` | Model Runtimes | MLServer midstream fork (carries AMD + ONNX patches), container image | GitHub repo; upstream `SeldonIO/MLServer` is orphaned |
+| `opendatahub-io/opendatahub-tests/tests/model_serving/model_runtime/` | Model Runtimes | All runtime integration tests (OVMS, MLServer, vLLM operator integration, Triton T&V) | GitHub tree |
+| `opendatahub-io/odh-model-controller/config/runtimes/` | Model Runtimes + Platform | Runtime template YAML definitions (kustomized into operator deployment) | GitHub tree |
+| `opendatahub-io/kserve` | KServe / Platform | Core CRDs (`ServingRuntime`, `InferenceService`, etc.), controllers, webhook validation | GitHub repo |
+| `opendatahub-io/odh-model-controller` | Platform | Companion controller: Routes, ServiceMonitors, CA bundles, KEDA, NIM integration, Model Registry sync | `architecture.md` |
+| vLLM container images (CUDA, ROCm, Gaudi) | RHAII | Engine builds (`registry.redhat.io`), engine-level feature testing | RHAII team backlog |
+| vLLM container images (CPU x86, Power, Z) | IBM (separate vLLM fork: `red-hat-data-services/vllm-cpu`) | CPU variant engine builds, arch-specific optimizations (VSX for Power, VXE for Z) | IBM team backlog |
+| vLLM container images (Spyre) | IBM Spyre team (`red-hat-data-services/vllm-spyre`) | IBM Spyre accelerator variant | IBM Spyre team backlog |
+| `opendatahub-io/opendatahub-tests/tests/model_serving/model_server/kserve/` | Platform / KServe | Platform-layer tests: route reconciliation, storage backends, token auth, KEDA autoscaling, ISVC lifecycle, observability | GitHub tree |
+| NVIDIA Triton image (`nvcr.io/nvidia/tritonserver`) | NVIDIA (vendor) | Image builds, backend maintenance, deprecation timeline | NVIDIA release notes |
+
+### Runtime Matrix
+
+#### OVMS (OpenVINO Model Server)
+
+- **Category**: Out-of-the-box Supported
+- **Repo**: `opendatahub-io/openvino_model_server` (midstream fork of `openvinotoolkit/model_server`)
+- **Template**: `kserve-ovms` (`ovms-kserve-template.yaml` in `config/runtimes/`)
+- **Image**: `registry.redhat.io` (sha256 pinned in CSV `relatedImages`)
+- **Supported formats**: OpenVINO IR, ONNX, TensorFlow SavedModel, PaddlePaddle, PyTorch (via conversion)
+- **GPU support**: Intel GPU only via `--target_device` argument
+  - `--target_device=AUTO` (default): CPU auto-selected
+  - `--target_device=GPU`: Intel integrated/discrete GPU
+  - **CUDA plugin deprecated in RHOAI 3.4** — NVIDIA GPU acceleration is NOT supported via OVMS going forward
+- **Default container args**: `--target_device=AUTO`, `--metrics_enable`, `--rest_port=8888`
+- **Protocols**: REST (v2 inference protocol, port 8888) + gRPC (grpc-v2, port 8033)
+- **Annotations**: `opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'`
+- **Test location**: `tests/model_serving/model_runtime/openvino/`
+
+Source: `opendatahub-io/openvino_model_server` README; `odh-model-controller/config/runtimes/ovms-kserve-template.yaml`
+
+#### MLServer
+
+- **Category**: Out-of-the-box Supported
+- **Repo**: `opendatahub-io/MLServer` (midstream fork of `SeldonIO/MLServer`)
+- **Template**: `mlserver-runtime-template` (`mlserver-template.yaml` in `config/runtimes/`)
+- **Image**: `registry.redhat.io` (sha256 pinned in CSV `relatedImages`)
+- **Supported formats**: LightGBM, ONNX, Sklearn (scikit-learn), XGBoost
+- **GPU support**: Via `onnxruntime-gpu` Python package swap:
+  - Replace `onnxruntime` with `onnxruntime-gpu` in container
+  - Configure CUDA/TensorRT execution providers
+  - No separate container image needed (unlike vLLM's per-accelerator images)
+- **Critical upstream context**:
+  - Upstream community (`SeldonIO/MLServer` on GitHub) is **dead/orphaned**
+  - Seldon (the parent company/sponsor) has been **liquidated**
+  - No new releases, no community PRs merged, no maintainer activity
+  - **AMD architecture support** (aarch64, ppc64le) is NOT in upstream
+  - **ONNX model format support** (full ONNXRuntime integration) is NOT in upstream
+  - Both AMD and ONNX support are added by Red Hat in `opendatahub-io/MLServer` midstream fork
+  - Model Runtimes team carries these patches indefinitely with zero upstream community support
+  - Implications: all MLServer bug fixes, security patches, and new features are Red Hat's sole burden
+- **Test location**: `tests/model_serving/model_runtime/mlserver/`
+
+Source: `opendatahub-io/MLServer` repo; `SeldonIO/MLServer` (last commit analysis); Seldon liquidation news
+
+#### vLLM
+
+- **Category**: Out-of-the-box Supported (7 platform-shipped variant templates)
+- **Templates** (all in `odh-model-controller/config/runtimes/`):
+  | Template | Accelerator | Image Owner |
+  |----------|-------------|-------------|
+  | `vllm-cuda-runtime-template` | NVIDIA GPU | RHAII |
+  | `vllm-rocm-runtime-template` | AMD GPU | RHAII |
+  | `vllm-gaudi-runtime-template` | Intel Gaudi (Habana) | RHAII |
+  | `vllm-spyre-x86-runtime-template` | IBM Spyre | IBM Spyre team (`red-hat-data-services/vllm-spyre`) |
+  | `vllm-cpu-x86-runtime-template` | x86 CPU | IBM (`red-hat-data-services/vllm-cpu`) |
+  | `vllm-cpu-power-runtime-template` | IBM Power CPU | IBM Power team (`red-hat-data-services/vllm-cpu`, ppc64le build) |
+  | `vllm-cpu-z-runtime-template` | IBM Z CPU | IBM Z team (`red-hat-data-services/vllm-cpu`, s390x build) |
+
+- **RHAII boundary** (critical ownership split):
+  - RHAII owns: vLLM engine source, CUDA/ROCm/Gaudi container image builds, engine-level features
+    (TGIS protocol, multimodal inference, quantization AWQ/Marlin, speculative decoding, tool calling,
+    performance benchmarks)
+  - IBM teams own: CPU variant image builds (`red-hat-data-services/vllm-cpu` fork — x86, Power, Z),
+    Spyre accelerator variant (`red-hat-data-services/vllm-spyre`)
+  - Model Runtimes owns: RHOAI operator integration tests (does the runtime deploy correctly, serve inference
+    via external routes, respond to probes, work with S3/PVC/OCI storage, function across accelerator variants)
+- **Protocols**: OpenAI-compatible REST API only (`/v1/completions`, `/v1/chat/completions`, `/v1/models`, `/health`)
+  - **gRPC is NOT supported** for vLLM in RHOAI OOTB templates
+  - All templates declare `opendatahub.io/apiProtocol: 'REST'` and use `vllm.entrypoints.openai.api_server`
+  - TGIS gRPC (port 8033) exists in some engine images but is RHAII scope, not exposed in platform templates
+  - Contrast: OVMS and Triton support both REST and gRPC protocols
+- **Test location**: `tests/model_serving/model_runtime/vllm/`
+
+Source: `odh-model-controller/config/runtimes/vllm-*.yaml`; PR #1679 (RHAII scope separation)
+
+### Protocol Support Matrix
+
+| Runtime | REST | gRPC | API Style | Template Annotation |
+|---------|------|------|-----------|---------------------|
+| **vLLM** | Yes (port 8080) | **No** | OpenAI-compatible (`/v1/completions`, `/v1/chat/completions`) | `opendatahub.io/apiProtocol: 'REST'` |
+| **OVMS** | Yes (port 8888) | Yes (port 8033) | KServe v2 inference protocol | `protocolVersions: [v2, grpc-v2]` |
+| **MLServer** | Yes (port 8080) | Yes (port 8081) | KServe v2 inference protocol | `protocolVersions: [v2, grpc-v2]` |
+| **Triton** | Yes (port 8080) | Yes (port 9000) | KServe v2 inference protocol | Defined inline in test CRD |
+
+**Key facts about vLLM protocol limitation:**
+- All vLLM OOTB templates use `python -m vllm.entrypoints.openai.api_server` — OpenAI REST only
+- Engine images may internally support TGIS gRPC (port 8033) via `vllm_tgis_adapter`, but this is NOT
+  exposed in platform ServingRuntime templates and is RHAII scope
+- `red-hat-data-services/vllm-cpu` has a `VllmEngine` gRPC (port 50051) but not wired into OOTB templates
+- Model Runtimes integration tests validate REST endpoints only for vLLM
+
+Source: `odh-model-controller/config/runtimes/vllm-*.yaml` (all declare REST); PR #1679 (TGIS tests removed)
+
+#### NVIDIA Triton
+
+- **Category**: Tested & Verified (NOT out-of-the-box)
+- **Template**: None — not in `odh-model-controller/config/runtimes/`; test creates ServingRuntime CRD directly
+- **Image**: `nvcr.io/nvidia/tritonserver:25.02-py3` (from NVIDIA GPU Cloud, not `registry.redhat.io`)
+  - Version 25.02 is pinned as the **last release** with TensorFlow backend included
+  - TensorFlow backend deprecated in 25.03, completely removed in 26.x+
+  - Image version managed in `tests/model_serving/model_runtime/triton/constant.py`
+- **Supported formats**: TensorRT, TensorFlow 1/2, ONNX, PyTorch (LibTorch), Triton (ensemble), XGBoost, Python, FIL (Forest Inference Library), DALI (GPU data pipeline), Keras
+- **Protocols**: REST (port 8080, v2 inference) + gRPC (port 9000, KServe Predict V2)
+- **Validation scope**: 7 model formats x 2 protocols = 14 test scenarios — this defines the support boundary
+- **Model Runtimes sole responsibility**: Defining the validation scope and maintaining the test suite
+- **Key distinction**: Customers deploy Triton as a "custom runtime" (create their own ServingRuntime CRD),
+  but unlike truly custom runtimes, Red Hat has tested and verified it within the defined scope
+- **gRPC tooling**: Uses `grpcurl` CLI with `grpc_predict_v2.proto` (stdin for payloads > 8KB)
+- **Test location**: `tests/model_serving/model_runtime/triton/`
+- **Not in image validation**: Absent from `image_validation/constant.py` `RUNTIME_CONFIGS` (confirms not platform-shipped)
+
+Source: `opendatahub-tests/triton/constant.py`; NVIDIA Triton release notes; `odh-model-controller/config/runtimes/` (absence confirms)
+
+### Testing Patterns (Current State)
+
+#### Shift 1: Fuzzy Validation Replaces Snapshot Comparison
+
+| Aspect | Legacy (removed) | Current |
+|--------|-----------------|---------|
+| Method | `assert response == response_snapshot` (syrupy) | `validate_text_inference_fuzzy()` |
+| Failure mode | Breaks across GPU types (FP precision) | Hardware-independent keyword matching |
+| Maintenance | Snapshot files need regeneration per HW | Zero maintenance |
+| PR | - | #1667 (amehtaja), #1641 |
+| Applied to | - | vLLM (all suites) |
+| Not yet applied | - | OVMS, MLServer, Triton (still use top-k) |
+
+The 7-step fuzzy validation pipeline:
+1. **Schema validation** — OpenAI response format with `choices[].message.content`
+2. **Non-emptiness** — minimum 3 words in response content
+3. **Content quality** — regex for 2+ char alphabetic words, 30%+ alpha character ratio
+4. **Error detection** — regex scan for traceback, CUDA OOM, segfault, NaN indicators
+5. **Repetition detection** — 4-gram phrase analysis, max 3 repeats allowed
+6. **Keyword matching** — at least one expected keyword from query definition found in response
+7. **Model info validation** — `/v1/models` returns list of dicts with `id` and `object` fields
+
+For predictive runtimes (OVMS, MLServer, Triton), the pattern is top-k classification with PR #1720 improvements:
+- `top_k = min(5, len(actual_data))` — flexible instead of hardcoded 5
+- `isinstance()` type-safety assertions before field access
+- `rawOutputContents` detection for gRPC binary responses
+
+Source: PR #1667, PR #1720 (amehtaja); `tests/model_serving/model_runtime/utils.py`
+
+#### Shift 2: External Routes Replace Port-Forwarding
+
+| Aspect | Legacy (removed) | Current |
+|--------|-----------------|---------|
+| Access method | `portforward.forward(pod, ns, port, port)` | `get_exposed_isvc_url(isvc)` → Route URL |
+| Realism | Pod-level (not enterprise) | Route-level (matches customer deployment) |
+| Dependency | Pod name lookup, port management | ISVC `status.url` field |
+| PR | - | #1713 (Raghul-M) |
+| Applied to | - | vLLM (all suites) |
+| Not yet applied | - | Triton (migration pending), OVMS, MLServer |
+
+The new pattern requires `external_route: True` in InferenceService fixture parameters.
+ODH Model Controller creates the OpenShift Route, and `status.url` is populated.
+`get_exposed_isvc_url(isvc)` reads this field and returns the base URL for inference.
+
+Source: PR #1713; `utilities/inference_utils.py` `get_exposed_isvc_url()` implementation
+
+#### Shift 3: Probe Testing as First-Class Concern
+
+New `vllm/probes/` suite (PR #1704, Raghul-M) validates readiness and liveness probes:
+
+| Probe | Path | Port | Initial Delay | Period | Timeout | Failure Threshold |
+|-------|------|------|---------------|--------|---------|-------------------|
+| Readiness | `/health` | 8080 | 120s | 10s | 10s | 12 |
+| Liveness | `/health` | 8080 | 180s | 30s | 10s | 10 |
+
+Test methodology:
+1. `ServingRuntimeFromTemplate` `containers` kwarg injects `httpGet` probes onto `kserve-container`
+2. Verify pod reaches `Ready` state
+3. Verify probe spec exists in pod spec (`readinessProbe.httpGet`, `livenessProbe.httpGet`)
+4. Execute in-pod `curl` to probe endpoint, assert HTTP 200
+5. Verify zero container restarts (no premature restarts during model loading)
+
+Source: PR #1704; `tests/model_serving/model_runtime/vllm/probes/utils.py`
+
+#### Shift 4: gRPC Response Handling (PR #1720)
+
+gRPC inference responses can contain data in two formats:
+- `rawOutputContents` / `raw_output_contents` — base64-encoded binary (Triton, OVMS gRPC)
+- `outputs[].data` — float array (REST, some gRPC implementations)
+
+Tests now detect and handle both:
+```
+if "rawOutputContents" in response or "raw_output_contents" in response:
+    raw_contents = response.get("rawOutputContents") or response.get("raw_output_contents")
+    assert raw_contents  # binary data present = valid response
+    return  # skip top-k comparison (binary not directly comparable)
+```
+
+Source: PR #1720 (amehtaja); `tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py`
+
+#### Shift 5: vLLM Refactored to RHOAI Integration Only (PR #1679)
+
+The vLLM test suite was completely restructured to remove RHAII-scope tests:
+
+| Removed (RHAII scope) | Retained (Model Runtimes scope) |
+|----------------------|--------------------------------|
+| `basic_model_deployment/` (TGIS, multi-model) | `s3/` — S3 storage backend |
+| `multimodal/` (Granite Vision) | `modelcar/` — OCI modelcar storage |
+| `quantization/` (AWQ) | `pvc/` — PVC storage backend |
+| `speculative_decoding/` | `probes/` — health probe validation |
+| `toolcalling/` | `cpu/` — CPU variant testing |
+| Serverless deployment tests | All use RawDeployment only |
+| Legacy `__snapshots__/` files | Fuzzy validation (no snapshots) |
+
+Source: PR #1679 (Raghul-M); current `tests/model_serving/model_runtime/vllm/` directory structure
+
+#### Shift 6: CPU Variant Support (PR #1723)
+
+New accelerator types added for CPU-only deployments:
+
+| Variant | Marker | Key Env Vars | Resources |
+|---------|--------|-------------|-----------|
+| x86 | `vllm_cpu_x86` | `VLLM_CPU_KVCACHE_SPACE=4`, `OMP_NUM_THREADS=8`, `VLLM_WORKER_MULTIPROC_METHOD=spawn` | 8-16 CPU, 10-16Gi mem |
+| IBM Power | `vllm_cpu_power` | bfloat16 dtype args | 12 CPU, 64Gi mem |
+| IBM Z | `vllm_cpu_z` | bfloat16 dtype args | 12 CPU, 64Gi mem |
+
+Source: PR #1723 (Raghul-M); `tests/model_serving/model_runtime/vllm/cpu/`
+
+### Dependencies Correction
+
+**RHAISTRAT-1868 incorrectly identifies dependencies on Dashboard and Platform teams for GPU support.**
+The actual mechanism requires NO code changes from these teams:
+
+| Mechanism | How It Works | Who Changes It |
+|-----------|-------------|----------------|
+| Template discovery | Annotation-driven: `opendatahub.io/dashboard: "true"`, `opendatahub.io/ootb: "true"` | No one — Dashboard reads annotations automatically |
+| Template deployment | Kustomize overlay in `odh-model-controller/config/runtimes/` | Model Runtimes (add YAML + kustomization entry) |
+| GPU injection | HardwareProfile webhook on `rhods-operator` | No one — webhook injects GPU limits automatically |
+| Route creation | ODH Model Controller watches ISVC with `external_route` annotation | No one — controller reconciles automatically |
+| Image shipping | CSV `relatedImages` in operator bundle | Release Engineering (bundle build pipeline) |
+
+To add a new out-of-the-box runtime template:
+1. Create YAML file in `odh-model-controller/config/runtimes/` with annotations
+2. Add to `kustomization.yaml` in the same directory
+3. Add image to operator CSV `relatedImages`
+4. Done — Dashboard discovers automatically, HardwareProfile handles GPU
+
+Source: `odh-model-controller/config/runtimes/kustomization.yaml`; Dashboard annotation scanning logic
+
+### Test Infrastructure
+
+| Fixture / Option | Purpose | Source File |
+|-----------------|---------|-------------|
+| `--vllm-runtime-image` / `VLLM_RUNTIME_IMAGE` | Override vLLM container image for CI | `conftest.py` (root) |
+| `--ovms-runtime-image` / `OVMS_RUNTIME_IMAGE` | Override OVMS container image for CI | `conftest.py` (root) |
+| `--mlserver-runtime-image` / `MLSERVER_RUNTIME_IMAGE` | Override MLServer container image for CI | `conftest.py` (root) |
+| `--triton-runtime-image` / `TRITON_RUNTIME_IMAGE` | Override Triton container image for CI | `conftest.py` (root) |
+| `--supported-accelerator-type` / `SUPPORTED_ACCELERATOR_TYPE` | Target: nvidia, amd, gaudi, spyre, cpu_x86, cpu_power, cpu_z | `conftest.py` (root) |
+| `ServingRuntimeFromTemplate` | Instantiate namespace-scoped SR from platform template | `utilities/serving_runtime.py` |
+| `create_isvc()` | Create InferenceService (external_route, deployment_mode, resources, probes, replicas) | `utilities/inference_utils.py` |
+| `get_exposed_isvc_url()` | Extract external route URL from ISVC `status.url` | `utilities/inference_utils.py` |
+| `skip_if_no_supported_accelerator_type` | Skip test if cluster lacks required accelerator | `conftest.py` markers |
+| `valid_aws_config` | Skip test if S3 credentials not configured | `conftest.py` markers |
+| `kserve_health_check` | Gate tests on KServe + ODH MC deployment health | `model_server/kserve/conftest.py` |
+
+### Key Test Utilities (Signatures)
+
+```
+ServingRuntimeFromTemplate(
+    client, name, namespace, template_name, deployment_type,
+    runtime_image=None, containers=None  # containers kwarg for probe injection
+)
+
+create_isvc(
+    client, name, namespace, runtime, storage_uri, model_format,
+    model_service_account=None, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+    external_route=True, resources=None, gpu_count=0, model_env_variables=None
+)
+
+get_exposed_isvc_url(isvc) -> str  # Returns "https://<route-host>"
+
+validate_text_inference_fuzzy(
+    completion_responses, queries, model_info,
+    require_keywords=False, allow_empty_responses=True, min_valid_responses=1
+)
+```
+
+Source: `utilities/serving_runtime.py`, `utilities/inference_utils.py`, `tests/model_serving/model_runtime/utils.py`
+
+## Impact on Strategies
+
+### Dependency Corrections (Source: RHAISTRAT-1868 analysis, odh-model-controller architecture)
+
+- **FALSE**: "Dashboard team needs code changes for new runtime templates"
+  - TRUTH: Dashboard discovers runtimes via annotations; zero code changes needed
+  - Source: Dashboard annotation scanning in `odh-dashboard/backend/`
+
+- **FALSE**: "Platform team delivers HardwareProfile changes for new runtimes"
+  - TRUTH: HardwareProfile webhook is generic; it works with ANY runtime automatically
+  - Source: `rhods-operator` webhook implementation
+
+- **FALSE**: "OVMS supports NVIDIA GPU via CUDA plugin"
+  - TRUTH: CUDA plugin is deprecated in RHOAI 3.4; OVMS is Intel GPU only going forward
+  - Source: OVMS 2024.5+ release notes; `opendatahub-io/openvino_model_server` build config
+
+### Scope Boundaries (Source: PR #1679, RHAII team structure)
+
+- Strategies proposing vLLM engine features (multimodal, tool calling, speculative decoding, quantization) as
+  Model Runtimes deliverables are **out of scope** — these are RHAII responsibility
+- Model Runtimes vLLM scope is limited to: operator integration (deploy, serve, probe, storage, routes, variants)
+
+### MLServer Risk (Source: SeldonIO/MLServer repo analysis, Seldon company liquidation)
+
+- Strategies involving MLServer enhancements must account for zero upstream community support
+- ALL patches (AMD arch, ONNX, security fixes) are carried solely by Model Runtimes team
+- Long-term MLServer roadmap is entirely Red Hat's decision with no community input
+
+### Triton Scope (Source: opendatahub-tests/triton/ test matrix)
+
+- Triton support is bounded by the 7x2 validation matrix (7 formats, 2 protocols)
+- Features outside this matrix (dynamic batching, BLS, custom backends, model ensembles beyond tested patterns)
+  are NOT part of the Tested & Verified designation
+- TensorFlow backend has limited shelf life (deprecated 25.03, removed 26.x+)
+
+### Testing Modernization (Source: PRs #1667, #1713, #1704, #1720)
+
+- New strategies should mandate: external routes (not port-forward), fuzzy validation (not snapshots),
+  probe testing (readiness + liveness), type-safe assertions
+- Triton migration to external routes is a pending modernization item
+- OVMS/MLServer may adopt fuzzy validation for cross-hardware GPU testing
+
+## Context
+
+The existing generated architecture docs for `openvino_model_server`, `MLServer`, and `vllm` describe each component
+in isolation but do not explain:
+- (a) How they compose with KServe/ODH Model Controller in the RawDeployment-only model
+- (b) The three-tier runtime taxonomy (out-of-the-box vs custom vs tested & verified)
+- (c) Which team owns what (Model Runtimes vs RHAII vs Platform vs vendor)
+- (d) The MLServer upstream orphan situation and Red Hat's sole maintenance burden
+- (e) The current testing patterns and their recent shifts (6 major changes in 2026)
+- (f) The HardwareProfile mechanism that eliminates Dashboard/Platform dependencies
+- (g) Triton's unique position as a Tested & Verified runtime with bounded scope
+
+This overlay bridges those gaps until the next architecture regeneration cycle incorporates these
+cross-cutting concerns into the individual component docs.
+
+Sources: `odh-model-controller/architecture.md`, PRs #1667/#1679/#1704/#1713/#1720/#1723,
+`utilities/serving_runtime.py`, `utilities/inference_utils.py`, `conftest.py` (root),
+`image_validation/constant.py`, RHAISTRAT-1868 analysis, Seldon liquidation context.

--- a/overlays/0015-vllm-variant-architecture.md
+++ b/overlays/0015-vllm-variant-architecture.md
@@ -41,9 +41,11 @@ accelerator or CPU architecture:
 
 Additional templates exist for multi-node (`vllm-multinode-template.yaml`) and Spyre ppc64le/s390x variants.
 
+OOTB vLLM templates reference `registry.redhat.io` images by SHA256 digest (via operator `params.env`; GPU variants managed by RHAII, CPU/Spyre variants by IBM teams) — not floating tags. Digest alignment is verified by `image_validation/` tests in `opendatahub-tests`.
+
 The `TEMPLATE_MAP` in `tests/model_serving/model_runtime/vllm/constant.py` resolves accelerator type to template:
 
-```
+```text
 nvidia  -> vllm-cuda-runtime-template
 amd     -> vllm-rocm-runtime-template
 gaudi   -> vllm-gaudi-runtime-template
@@ -104,7 +106,7 @@ covered by the RHAII team:
 
 ### Current Test Directory Structure
 
-```
+```text
 tests/model_serving/model_runtime/vllm/
 ├── conftest.py          # Main fixtures: serving_runtime, vllm_inference_service (external_route=True)
 ├── constant.py          # TEMPLATE_MAP, ACCELERATOR_IDENTIFIER, queries with keywords
@@ -156,7 +158,7 @@ tests/model_serving/model_runtime/vllm/
 
 All vLLM tests deploy with `external_route: True` and access REST inference via `get_exposed_isvc_url(isvc)`:
 
-```
+```text
 InferenceService (external_route=True) -> ODH Model Controller creates Route
                                        -> status.url populated with external hostname
                                        -> Tests call get_exposed_isvc_url(isvc) -> base URL
@@ -176,7 +178,7 @@ Port-forwarding has been completely removed from vLLM tests (PR #1713). The `pod
 
 All vLLM tests use `validate_text_inference_fuzzy()` with keyword-based validation:
 
-```
+```python
 COMPLETION_QUERY = [
     {"text": "List the top five breeds of dogs...", "keywords": ["dog", "breed", "labrador", ...]},
     ...

--- a/overlays/0015-vllm-variant-architecture.md
+++ b/overlays/0015-vllm-variant-architecture.md
@@ -1,0 +1,267 @@
+---
+id: "0015"
+title: vLLM variant architecture — accelerator matrix, test suite structure, and RHAII boundary
+status: active
+created: 2026-06-13
+affects:
+  - vllm
+  - odh-model-controller
+  - opendatahub-tests
+release:
+  - "3.4"
+  - "3.5"
+  - "next"
+provenance:
+  - https://github.com/opendatahub-io/opendatahub-tests/tree/main/tests/model_serving/model_runtime/vllm
+  - https://github.com/opendatahub-io/odh-model-controller/tree/main/config/runtimes
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1679
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1713
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1704
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1723
+author: Imran Khalidi, Model Runtimes Team
+superseded_by: null
+---
+
+## Fact
+
+### Variant Matrix
+
+vLLM ships as 7 platform templates in `odh-model-controller/config/runtimes/`, each targeting a different
+accelerator or CPU architecture:
+
+| Accelerator Type | Template Name | Image Owner | Resource Identifier |
+|-----------------|---------------|-------------|---------------------|
+| `nvidia` | `vllm-cuda-runtime-template` | RHAII | `nvidia.com/gpu` |
+| `amd` | `vllm-rocm-runtime-template` | RHAII | `amd.com/gpu` |
+| `gaudi` | `vllm-gaudi-runtime-template` | RHAII | `habana.ai/gaudi` |
+| `spyre` | `vllm-spyre-x86-runtime-template` | IBM Spyre team (`red-hat-data-services/vllm-spyre`) | `ibm.com/spyre_pf` |
+| `cpu_x86` | `vllm-cpu-x86-runtime-template` | IBM (`red-hat-data-services/vllm-cpu`) | CPU label |
+| `cpu_power` | `vllm-cpu-power-runtime-template` | IBM Power team (`red-hat-data-services/vllm-cpu`, ppc64le) | CPU label |
+| `cpu_z` | `vllm-cpu-z-runtime-template` | IBM Z team (`red-hat-data-services/vllm-cpu`, s390x) | CPU label |
+
+Additional templates exist for multi-node (`vllm-multinode-template.yaml`) and Spyre ppc64le/s390x variants.
+
+The `TEMPLATE_MAP` in `tests/model_serving/model_runtime/vllm/constant.py` resolves accelerator type to template:
+
+```
+nvidia  -> vllm-cuda-runtime-template
+amd     -> vllm-rocm-runtime-template
+gaudi   -> vllm-gaudi-runtime-template
+spyre   -> vllm-spyre-x86-runtime-template
+cpu_x86 -> vllm-cpu-x86-runtime-template
+cpu_power -> vllm-cpu-power-runtime-template
+cpu_z   -> vllm-cpu-z-runtime-template
+```
+
+### RHAII Boundary
+
+RHAII (Red Hat AI Inference) team owns:
+- vLLM engine source code and GPU container image builds (CUDA, ROCm, Gaudi)
+- Engine-level feature testing: TGIS protocol, multimodal inference, quantization (AWQ/Marlin),
+  speculative decoding, tool calling, performance benchmarks
+
+IBM teams own (via separate vLLM forks under `red-hat-data-services/`):
+- `red-hat-data-services/vllm-cpu`: All CPU variant builds (x86, Power ppc64le, Z s390x)
+  - IBM Power team handles ppc64le arch (VSX kernel optimizations)
+  - IBM Z team handles s390x arch (VXE kernel optimizations)
+  - x86 CPU variant also built from this fork
+- `red-hat-data-services/vllm-spyre`: IBM Spyre accelerator variant
+
+Model Runtimes team owns:
+- RHOAI operator integration tests (does the runtime work correctly on the platform?)
+- Storage backends: S3, PVC, OCI modelcar
+- Deployment modes: RawDeployment with external routes
+- Health probes: readiness and liveness validation
+- CPU variant testing: x86, IBM Power, IBM Z (testing the operator integration, not the engine)
+- Image validation: sha256 digests, registry.redhat.io sourcing
+
+### Protocol: REST Only (No gRPC)
+
+vLLM in RHOAI is **REST-only**. gRPC is NOT a supported protocol:
+- All OOTB templates declare `opendatahub.io/apiProtocol: 'REST'`
+- Entrypoint: `python -m vllm.entrypoints.openai.api_server` on port 8080
+- Supported endpoints: `/v1/completions`, `/v1/chat/completions`, `/v1/models`, `/health`
+- TGIS gRPC (port 8033) exists in some engine images but is NOT exposed in platform templates (RHAII scope)
+- All Model Runtimes integration tests validate REST only
+
+This contrasts with OVMS (REST + gRPC via `grpc-v2`) and Triton (REST + gRPC on port 9000).
+
+### Removed Legacy Suites (PR #1679)
+
+The following test directories were removed from `vllm/basic_model_deployment/` as they are now
+covered by the RHAII team:
+
+| Removed Suite | Reason |
+|--------------|--------|
+| `basic_model_deployment/` (multi-model tests) | RHAII covers full model deployment matrix |
+| `multimodal/` (Granite Vision) | RHAII owns multimodal testing |
+| `quantization/` (AWQ) | RHAII owns quantization validation |
+| `speculative_decoding/` (draft, n-gram) | RHAII owns speculative decoding |
+| `toolcalling/` (function calling) | RHAII owns tool calling tests |
+| TGIS protocol tests | TGIS is RHAII scope |
+| Serverless deployment tests | RHOAI exclusively uses RawDeployment |
+| Legacy snapshot files (`__snapshots__/`) | Replaced by fuzzy validation |
+
+### Current Test Directory Structure
+
+```
+tests/model_serving/model_runtime/vllm/
+├── conftest.py          # Main fixtures: serving_runtime, vllm_inference_service (external_route=True)
+├── constant.py          # TEMPLATE_MAP, ACCELERATOR_IDENTIFIER, queries with keywords
+├── utils.py             # run_raw_inference (external route), validate_raw_openai_inference_request
+├── s3/                  # S3-backed raw deployment
+│   ├── test_granite_7b_starter.py
+│   └── test_llama3_8B_instruct.py
+├── modelcar/            # OCI modelcar YAML-driven validation
+│   ├── conftest.py      # pytest_generate_tests reads YAML config
+│   ├── sample_modelcar_config.yaml
+│   ├── test_modelvalidation.py
+│   └── utils.py
+├── pvc/                 # PVC-backed model storage
+│   ├── conftest.py
+│   └── test_vllm_pvc_inference.py
+├── probes/              # Readiness/liveness probe validation
+│   ├── conftest.py      # probes_serving_runtime with httpGet injection
+│   ├── test_vllm_probes.py
+│   └── utils.py         # VLLM_READINESS_PROBE, VLLM_LIVENESS_PROBE definitions
+└── cpu/                 # CPU variant testing
+    ├── cpu_x86/
+    │   ├── conftest.py  # cpu_x86_serving_runtime, cpu_x86_inference_service
+    │   ├── constant.py  # CPU_X86_ENV_VARIABLES, resources, serving args
+    │   ├── test_vllm_cpu_s3_inference.py
+    │   └── utils.py
+    └── ibm_power_z/
+        ├── conftest.py
+        ├── constant.py  # bfloat16, 12 CPU / 64Gi resources
+        ├── test_falcon3_7b_instruct.py
+        ├── test_granite_3_1_8b_instruct.py
+        ├── test_llama_3_2_1b_instruct.py
+        ├── test_mistral_7b_instruct.py
+        ├── test_phi_4.py
+        └── utils.py
+```
+
+### Test Markers
+
+| Marker | Scope | Requires |
+|--------|-------|----------|
+| `vllm_nvidia_single_gpu` | Single NVIDIA GPU tests | 1x `nvidia.com/gpu` |
+| `vllm_nvidia_multi_gpu` | Multi-GPU NVIDIA tests | 2+ `nvidia.com/gpu` |
+| `vllm_amd_gpu` | AMD ROCm GPU tests | 1x `amd.com/gpu` |
+| `vllm_cpu_x86` | x86 CPU-only tests | x86 CPU accelerator |
+| `vllm_cpu_power` | IBM Power CPU tests | Power CPU accelerator |
+| `vllm_cpu_z` | IBM Z CPU tests | Z CPU accelerator |
+
+### Inference Pattern: External Routes (REST Only)
+
+All vLLM tests deploy with `external_route: True` and access REST inference via `get_exposed_isvc_url(isvc)`:
+
+```
+InferenceService (external_route=True) -> ODH Model Controller creates Route
+                                       -> status.url populated with external hostname
+                                       -> Tests call get_exposed_isvc_url(isvc) -> base URL
+                                       -> OpenAI-compatible REST requests to external URL
+                                       -> /v1/completions, /v1/chat/completions, /v1/models
+```
+
+gRPC is NOT used — all vLLM tests are REST-only (OpenAI-compatible API).
+
+The `run_raw_inference()` function uses `@retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))`
+for resilience against transient route propagation delays.
+
+Port-forwarding has been completely removed from vLLM tests (PR #1713). The `pod_name` parameter and
+`vllm_pod_resource` fixture are no longer used for text inference.
+
+### Validation Pattern: Fuzzy Keyword Matching
+
+All vLLM tests use `validate_text_inference_fuzzy()` with keyword-based validation:
+
+```
+COMPLETION_QUERY = [
+    {"text": "List the top five breeds of dogs...", "keywords": ["dog", "breed", "labrador", ...]},
+    ...
+]
+```
+
+The 7-step validation pipeline:
+1. Schema validation (OpenAI response format with `choices`)
+2. Non-emptiness (minimum 3 words)
+3. Content quality (regex for 2+ char alphabetic words, 30%+ alpha ratio)
+4. Error detection (regex for traceback, CUDA error, OOM, segfault indicators)
+5. Repetition detection (4-gram phrases max 3 repeats)
+6. Keyword matching (at least one expected keyword in response)
+7. Model info validation (list of dicts with `id` and `object` fields)
+
+Snapshot comparison (`syrupy`) is only used when `CHECK_SNAPSHOT=true` env var is set (disabled by default).
+
+### Probe Testing
+
+The `probes/` suite validates that vLLM predictor pods have correctly functioning health probes:
+
+| Probe | Path | Port | Initial Delay | Period | Timeout | Failure Threshold |
+|-------|------|------|---------------|--------|---------|-------------------|
+| Readiness | `/health` | 8080 | 120s | 10s | 10s | 12 |
+| Liveness | `/health` | 8080 | 180s | 30s | 10s | 10 |
+
+Probes are injected via `ServingRuntimeFromTemplate` `containers` kwarg onto `kserve-container`.
+Tests verify: pod is Ready, probe httpGet spec exists, in-pod curl returns HTTP 200, no premature
+container restarts during model load.
+
+### YAML-Driven Modelcar Testing
+
+The modelcar suite uses `sample_modelcar_config.yaml` to define test models dynamically:
+
+```yaml
+model-car:
+  - name: granite-3.1-8b-instruct
+    image: oci://registry.stage.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct:1.5
+    model_output_type: text
+    serving_arguments:
+      args: ["--uvicorn-log-level=info", "--max-model-len=1024", "--trust-remote-code"]
+      gpu_count: 1
+  - name: whisper-large-v3
+    image: oci://registry.redhat.io/rhelai1/modelcar-whisper-large-v2-w4a16-g128:1.5
+    model_output_type: audio
+  - name: embedding-gemma
+    image: oci://registry.redhat.io/rhelai1/modelcar-embeddinggemma-300m:1.5
+    model_output_type: embedding
+```
+
+`pytest_generate_tests()` in the modelcar `conftest.py` reads this YAML and generates parameterized
+test cases for each model, supporting text, audio, and embedding output types.
+
+### CPU Variant Resources
+
+CPU variants use dedicated resource configurations:
+
+| Variant | CPU Request | CPU Limit | Memory | Shared Memory | Key Env Vars |
+|---------|------------|-----------|--------|---------------|--------------|
+| x86 | 8 | 16 | 10-16Gi | 32Gi | `VLLM_CPU_KVCACHE_SPACE=4`, `OMP_NUM_THREADS=8`, `VLLM_WORKER_MULTIPROC_METHOD=spawn` |
+| IBM Power/Z | 12 | 12 | 64Gi | 32Gi | bfloat16 serving args |
+
+CPU x86 tests use small models (opt-125m, TinyLlama-1.1B) with `--enforce-eager --max-model-len=256`.
+IBM Power/Z tests use larger instruct models (Falcon3-7B, Llama-3.2, Phi-4, Mistral-7B, Granite-3.1-8B)
+with `--dtype=bfloat16`.
+
+## Impact on Strategies
+
+- Strategies involving new vLLM GPU accelerator support (CUDA, ROCm, Gaudi) must go to RHAII — they own those
+  engine builds. Model Runtimes only tests the operator integration.
+- Strategies for IBM CPU variants (x86, Power, Z) must coordinate with the respective IBM teams who maintain
+  the `red-hat-data-services/vllm-cpu` fork. Model Runtimes tests integration only.
+- Strategies for IBM Spyre must coordinate with the IBM Spyre team (`red-hat-data-services/vllm-spyre`).
+- CPU variant strategies should follow the pattern established in PR #1723: new marker, new constant file with
+  resources/env vars, new conftest with serving_runtime and inference_service fixtures, new test module.
+- Any strategy proposing to add vLLM engine features (multimodal, tool calling, etc.) to the Model Runtimes test
+  suite is out of scope — these are RHAII responsibility.
+- Strategies for PVC, S3, or OCI modelcar storage improvements affect the Model Runtimes test suite directly.
+- **gRPC support for vLLM is NOT in scope** — vLLM OOTB templates are REST-only (OpenAI API). Any gRPC
+  strategy for vLLM (TGIS, KServe v2 gRPC) is RHAII engine scope, not Model Runtimes.
+
+## Context
+
+The vLLM test suite underwent a major refactoring in June 2026 (PR #1679) to remove RHAII-scope tests and establish
+a clear boundary. Subsequent PRs (#1713, #1704, #1723, #1730) added external route inference, probe testing, CPU
+variants, and multi-GPU support. The generated architecture docs for `vllm` do not reflect this team boundary or the
+new test infrastructure. This overlay documents the current state and provides patterns for skills-based test case
+generation.

--- a/overlays/0016-triton-tested-verified-runtime.md
+++ b/overlays/0016-triton-tested-verified-runtime.md
@@ -45,9 +45,8 @@ Pinned version rationale: 25.02 is the last release with TensorFlow backend
 
 | Version | TensorFlow Status |
 |---------|-------------------|
-| 25.02 | Included (last release) |
-| 25.03 | Deprecated |
-| 26.x+ | Removed completely |
+| 25.02 | Included (last release; current test pin — no CVE support, NVIDIA-managed image) |
+| 25.03+ | Deprecated and removed (v2.56.0) |
 
 The image version is managed in `tests/model_serving/model_runtime/triton/constant.py`:
 
@@ -112,7 +111,7 @@ Pod name from get_pods_by_isvc_label() -> portforward.forward(pod, namespace, po
 gRPC uses the `grpcurl` CLI tool with `utilities/manifests/common/grpc_predict_v2.proto`. For large
 payloads (>8KB), input is passed via stdin from a temp file rather than inline `-d`.
 
-Migration to external routes (following PR #1713 pattern) is pending.
+Migration to external routes (following PR #1713 pattern) is tracked but has no committed release target. Port-forwarding remains acceptable for the T&V validation scope — tests exercise KServe/ODH Model Controller reconciliation and inference correctness, not production route-exposure patterns.
 
 ### Validation Pattern
 
@@ -204,9 +203,8 @@ kserve-triton-fil-rest-input.json       kserve-triton-fil-gRPC-input.json
   be coordinated with Model Runtimes team as they define the support boundary.
 - Strategies proposing Triton features outside the validated scope (e.g., dynamic batching, model ensembles,
   BLS) should explicitly note these are not covered by Tested & Verified designation.
-- The TensorFlow backend deprecation means strategies relying on TF models via Triton have a limited shelf
-  life — eventually the image will need to drop TF tests or find an alternative.
-- Migration from port-forward to external routes is pending and should be included in test modernization strategies.
+- The TensorFlow backend was deprecated and removed from 25.03 onward (v2.56.0). Strategies relying on TF models via Triton have a limited shelf life — the deliberate 25.02 pin preserves TF coverage for the current test matrix, but migration will eventually require dropping TF tests or finding an alternative backend. No CVE support applies — Red Hat does not ship the Triton image; we support the deployment integration layer only
+- Migration from port-forward to external routes is tracked (no committed release target) and should be included in test modernization strategies when scheduled.
 
 ## Context
 

--- a/overlays/0016-triton-tested-verified-runtime.md
+++ b/overlays/0016-triton-tested-verified-runtime.md
@@ -1,0 +1,216 @@
+---
+id: "0016"
+title: "NVIDIA Triton — Tested & Verified runtime architecture and validation scope"
+status: active
+created: 2026-06-13
+affects:
+  - opendatahub-tests
+  - kserve
+release:
+  - "3.4"
+  - "3.5"
+  - "next"
+provenance:
+  - https://github.com/opendatahub-io/opendatahub-tests/tree/main/tests/model_serving/model_runtime/triton
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1327
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1435
+  - https://github.com/opendatahub-io/opendatahub-tests/pull/1720
+  - https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/
+author: Imran Khalidi, Model Runtimes Team
+superseded_by: null
+---
+
+## Fact
+
+### Runtime Category: Tested & Verified
+
+NVIDIA Triton Inference Server is classified as a **Tested & Verified** runtime in RHOAI:
+
+- NOT shipped with RHOAI (not in CSV `relatedImages`, not in `registry.redhat.io`)
+- NOT in `odh-model-controller/config/runtimes/` (no platform template exists)
+- Deployed by customers as a **custom runtime** (they create their own ServingRuntime CRD)
+- Red Hat tests and verifies it with a **defined validation scope**
+- Support is limited to what falls within that validation scope
+
+The validation scope defines the support boundary: what is tested is what is supported.
+Model Runtimes team is solely responsible for defining, creating, and maintaining this scope.
+
+### Image Management
+
+```
+Image: nvcr.io/nvidia/tritonserver:25.02-py3
+Source: NVIDIA GPU Cloud registry (not Red Hat registry)
+Pinned version rationale: 25.02 is the last release with TensorFlow backend
+```
+
+| Version | TensorFlow Status |
+|---------|-------------------|
+| 25.02 | Included (last release) |
+| 25.03 | Deprecated |
+| 26.x+ | Removed completely |
+
+The image version is managed in `tests/model_serving/model_runtime/triton/constant.py`:
+
+```
+TRITON_IMAGE: str = "nvcr.io/nvidia/tritonserver:25.02-py3"
+```
+
+The `--triton-runtime-image` pytest option / `TRITON_RUNTIME_IMAGE` env var allows CI to override this.
+
+### Defined Validation Scope
+
+The following matrix defines what is tested and hence supported:
+
+| Model Format | Model Name | REST | gRPC | Test Tier | GPU Required |
+|-------------|------------|------|------|-----------|--------------|
+| ONNX | densenetonnx | Yes | Yes | tier1 | No |
+| PyTorch | resnet50 | Yes | Yes | tier1 | No |
+| TensorFlow | inceptiongraphdef | Yes | Yes | smoke | No |
+| Keras | resnet | Yes | Yes | tier1 | No |
+| Python | python (custom) | Yes | Yes | tier1 | No |
+| FIL (tree-based) | fil | Yes | Yes | tier1 | No |
+| DALI (GPU pipeline) | daligpu | Yes | Yes | tier1 | Yes |
+
+**Total: 7 model formats x 2 protocols = 14 validated test scenarios**
+
+Anything outside this matrix (e.g., TensorRT-specific features, Triton ensemble pipelines beyond what is
+tested, custom backends, dynamic batching configuration) is NOT validated and NOT supported under the
+Tested & Verified designation.
+
+### ServingRuntime Definition (Custom CRD)
+
+Unlike out-of-the-box runtimes that use platform templates, Triton tests create the full ServingRuntime
+spec inline via OpenShift Template objects:
+
+```
+Test conftest.py -> create_triton_template() -> OpenShift Template
+                 -> ServingRuntimeFromTemplate -> namespace-scoped ServingRuntime
+                 -> InferenceService -> KServe reconciles
+```
+
+The runtime spec includes:
+
+| Field | REST Runtime | gRPC Runtime |
+|-------|-------------|--------------|
+| Name | `triton-rest-runtime` | `triton-grpc-runtime` |
+| Port | 8080 (http1) | 9000 (h2c) |
+| Shared memory | None | 2Gi `/dev/shm` |
+| Protocol versions | `v2`, `grpc-v2` | `v2`, `grpc-v2` |
+| Supported formats | tensorrt, tensorflow 1/2, onnx, pytorch, triton, xgboost, python | Same |
+| Container args | `tritonserver --model-store=/mnt/models --http-port=8080 --allow-http=True` | `tritonserver --model-store=/mnt/models --grpc-port=9000 --allow-grpc=True` |
+
+### Inference Access Pattern
+
+Triton tests currently use **port-forwarding** (NOT yet migrated to external routes):
+
+```
+Pod name from get_pods_by_isvc_label() -> portforward.forward(pod, namespace, port, port)
+  REST: requests.post(f"http://localhost:{port}/v2/models/{model}/infer", json=input_data)
+  gRPC: grpcurl -plaintext -import-path <proto_dir> -proto grpc_predict_v2.proto localhost:port inference.GRPCInferenceService/ModelInfer
+```
+
+gRPC uses the `grpcurl` CLI tool with `utilities/manifests/common/grpc_predict_v2.proto`. For large
+payloads (>8KB), input is passed via stdin from a temp file rather than inline `-d`.
+
+Migration to external routes (following PR #1713 pattern) is pending.
+
+### Validation Pattern
+
+Triton uses top-k classification validation (not fuzzy text validation):
+
+```
+Response structure: {"outputs": [{"data": [0.123, 0.456, ...]}]}
+
+1. Assert response is not empty
+2. Assert response is a dict (type-safe, PR #1720)
+3. Assert outputs list is non-empty
+4. Assert first output is a dict (type-safe, PR #1720)
+5. Handle gRPC: if rawOutputContents present, assert non-empty and return
+6. Extract data array
+7. Compute top_k = min(5, len(actual_data))  (flexible, PR #1720)
+8. Sort indices by value descending, take top_k
+9. Assert all indices are valid integers in range
+```
+
+### GPU Handling
+
+| Accelerator | Identifier | Default |
+|-------------|-----------|---------|
+| NVIDIA | `nvidia.com/gpu` | Yes (fallback) |
+| AMD | `amd.com/gpu` | Supported via mapping |
+
+GPU resources are added to InferenceService when `gpu_count > 0`. The DALI model test is the only
+test requiring GPU (marked `pytest.mark.gpu`). Other model format tests run on CPU.
+
+### Resource Configuration
+
+| Resource | Base (CPU) | Multi-GPU |
+|----------|-----------|-----------|
+| CPU requests | 1 | 1 |
+| CPU limits | 2 | 2 |
+| Memory requests | 2Gi | 2Gi |
+| Memory limits | 4Gi | 4Gi |
+| Shared memory | - | 16Gi `/dev/shm` |
+| Temp volume | - | `/tmp` |
+| Home volume | - | `/home/triton` |
+
+### Test Structure
+
+```
+tests/model_serving/model_runtime/triton/
+├── __init__.py
+├── constant.py              # TRITON_IMAGE, ports, paths, TEMPLATE_MAP, RUNTIME_MAP, resources
+└── basic_model_deployment/
+    ├── __init__.py
+    ├── conftest.py          # triton_serving_runtime, triton_inference_service, template fixtures
+    ├── utils.py             # send_rest_request, send_grpc_request, run_triton_inference, validate
+    ├── test_onnx_model.py
+    ├── test_pytorch_model.py
+    ├── test_tensorflow_model.py
+    ├── test_keras_model.py
+    ├── test_python_model.py
+    ├── test_fil_model.py
+    ├── test_dali_model.py
+    ├── __snapshots__/       # JSON snapshot files (legacy, being replaced by flexible validation)
+    └── kserve-triton-*-input.json  # Pre-built inference input payloads (REST + gRPC per format)
+```
+
+### Input Data Files
+
+Each model format has pre-built JSON input payloads for both REST and gRPC:
+
+```
+kserve-triton-onnx-rest-input.json      kserve-triton-onnx-gRPC-input.json
+kserve-triton-python-rest-input.json    kserve-triton-python-gRPC-input.json
+kserve-keras-triton-resnet-rest-input.json  kserve-keras-triton-resnet-gRPC-input.json
+kserve-triton-tensorflow-rest-input.json  kserve-triton-tensorflow-gRPC-input.json
+kserve-triton-resnet-rest-input.json    kserve-triton-resnet-gRPC-input.json  (PyTorch)
+kserve-triton-dali-rest-input.json      kserve-triton-dali-gRPC-input.json
+kserve-triton-fil-rest-input.json       kserve-triton-fil-gRPC-input.json
+```
+
+### Key Fixes History
+
+| PR | Date | Fix |
+|----|------|-----|
+| #1155 | 2026-03 | Handle None/empty accelerator type, default to NVIDIA |
+| #1327 | 2026-03 | Update image to 25.02 for TensorFlow backend support |
+| #1435 | 2026-04 | Adjust smoke/tier1 markers, add standard deployment utils |
+| #1720 | 2026-06 | Add type-safety, flexible top-k, gRPC rawOutputContents handling |
+
+## Impact on Strategies
+
+- Strategies expanding Triton validation scope (new model formats, new protocols, new deployment modes) must
+  be coordinated with Model Runtimes team as they define the support boundary.
+- Strategies proposing Triton features outside the validated scope (e.g., dynamic batching, model ensembles,
+  BLS) should explicitly note these are not covered by Tested & Verified designation.
+- The TensorFlow backend deprecation means strategies relying on TF models via Triton have a limited shelf
+  life — eventually the image will need to drop TF tests or find an alternative.
+- Migration from port-forward to external routes is pending and should be included in test modernization strategies.
+
+## Context
+
+The generated architecture docs do not mention Triton because it is not a component in any `opendatahub-io` repository
+(it lives in NVIDIA's registry). The test suite in `opendatahub-tests` is the sole artifact defining the Tested &
+Verified boundary. This overlay documents that boundary, the testing patterns, and the custom runtime deployment
+mechanism so that strategies and RFEs can correctly scope Triton-related work.


### PR DESCRIPTION
## Summary

Adds three architecture overlays documenting Model Runtimes team context that is not captured by per-component auto-generation:

- **0014 — Model Runtimes team architecture**: Team-level ownership map, KServe integration patterns, three-tier runtime taxonomy (Platform-shipped / Tested & Verified / Custom), runtime matrix with accelerator support, testing patterns and directory structure, dependency corrections (Dashboard annotation-driven discovery, HardwareProfile generic matching, OVMS CUDA deprecation)
- **0015 — vLLM variant architecture**: 7 ServingRuntime templates, accelerator-per-image model, RHAII ownership boundary, test suite structure after pytest migration, CPU variant details
- **0016 — Triton Tested & Verified runtime**: Bounded validation scope, NVIDIA-managed vendor image, version pinning strategy, TensorFlow backend deprecation timeline

## Why these are needed

Generated architecture docs are per-component. They miss cross-cutting context that spans multiple components under one team's ownership:
- Which team owns what (and where ownership boundaries sit between RHOAI / RHAII / IBM)
- How runtimes are added to the platform (annotation-driven, no cross-team dependency)
- Which GPU acceleration paths are viable vs. deprecated
- Testing patterns that span all runtimes (shared fixtures, directory conventions)

Without this context, strategy pipelines and architecture reviews produce incorrect dependency graphs and infeasible deliverables.

## Consumers that benefit

- Strategy generation pipelines (strat-creator)
- Architecture reviews and design validation
- Cross-team planning (accurate dependency identification)

## Checklist

- [x] Only `overlays/` modified — no changes to `architecture/`
- [x] YAML frontmatter follows schema (id, title, status, created, affects, release, provenance, author, superseded_by)
- [x] Three body sections present: `## Fact`, `## Impact on Strategies`, `## Context`
- [x] Content is factual with provenance links — no opinions or future plans
- [x] IDs 0014-0016 are next in sequence (upstream max is 0013)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Model Runtimes team architecture documentation covering end-to-end runtime lifecycle patterns, ownership boundaries, supported runtime/protocol matrices, and updated 2026 testing approach (e.g., fuzzy validation and probe/readiness modernization).
  * Added vLLM runtime/variant documentation detailing template/accelerator mappings, digest-pinned image expectations, REST-only behavior, and updated vLLM test suite scope and validation strategy.
  * Added Triton “Tested & Verified” runtime documentation specifying custom deployment expectations, supported model-format × protocol matrix, current validation mechanics, and planned access method updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->