### PR TITLE
overlays: add skill and update 0017 AIPCC base images

### DIFF
--- a/.claude/skills/update-aipcc-base-images-overlay/SKILL.md
+++ b/.claude/skills/update-aipcc-base-images-overlay/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: update-aipcc-base-images-overlay
+description: Use when the AIPCC base image repository has changed and the overlay file overlays/0017-aipcc-base-images.md needs to be refreshed with current accelerator support information, versions, or architecture details.
+user-invocable: true
+allowed-tools: Read, Write, Bash(bash ${CLAUDE_SKILL_DIR}/scripts/fetch-base-images-repo.sh), Bash(./tmp/app/bin/generate-platform-docs.py), Glob, Grep
+---
+
+# Update AIPCC Base Images Overlay
+
+Refresh `overlays/0017-aipcc-base-images.md` with current information from the
+AIPCC base images repository.
+
+## Overview
+
+The overlay documents the accelerator variants (CPU, CUDA, ROCm, Gaudi, Spyre,
+Neuron, TPU) built from the base-images/app repository. It is used to evaluate
+RFEs that propose changes to accelerator support. When the repository changes,
+run this skill to update the overlay.
+
+## Instructions
+
+### Step 1: Clone or Update the Repository
+
+Run the fetch script from the root of the architecture-context repository:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/fetch-base-images-repo.sh
+```
+
+This clones `https://gitlab.com/redhat/rhel-ai/core/base-images/app.git` to
+`./tmp/app`, or pulls the latest changes if the clone already exists.
+
+### Step 2: Generate Tables from the Repository
+
+Run the repository's own documentation generator as an executable:
+
+```bash
+./tmp/app/bin/generate-platform-docs.py
+```
+
+Capture the full output — it contains the accelerator summary table and
+per-variant details that form the factual base of the overlay.
+
+If the script produces output files rather than printing to stdout, read those
+files to get the generated content.
+
+### Step 3: Read the Current Overlay
+
+Read the current content of `overlays/0017-aipcc-base-images.md` to understand
+the existing structure, especially the "Impact on Strategies" and "Context"
+sections, which contain human-authored guidance that must be preserved and
+updated — not replaced wholesale.
+
+### Step 4: Update the Overlay
+
+Rewrite `overlays/0017-aipcc-base-images.md` using the following approach:
+
+**Preserve the YAML front matter** (`id`, `title`, `status`, `created`,
+`affects`, `release`, `provenance`, `author`, `superseded_by`). Update
+`release` only if the repository clearly targets a new RHEL AI release.
+
+**Fact section** — Replace entirely with fresh content derived from the
+generator output and the repository. This section must describe:
+
+- What the base images are and how downstream teams use them
+- The common foundation (base OS, Python version, RHEL AI repo version,
+  package index version, repositories, container layout, environment metadata,
+  helper script)
+- An **Accelerator Summary** table with columns:
+  `Accelerator | Version | Status | Python | RHEL | aarch64 | ppc64le | s390x | x86_64`
+- A **Status Legend** explaining Active / In development / Disabled / Retired
+- One subsection per accelerator variant (CPU, NVIDIA CUDA variants, AMD ROCm,
+  Intel Gaudi, IBM Spyre, AWS Neuron, Google TPU) covering: status, config
+  file, architectures, container image, driver requirements (if applicable),
+  and key dependencies
+- A **Retired Accelerators** subsection for anything removed from the repo
+
+**Impact on Strategies section** — Update to reflect the current state of each
+accelerator variant. The section must include at least:
+
+- A bullet noting that all RHAI components using accelerator-specific Python
+  libraries must use these base images
+- Bullets for each non-Active variant (in-development, disabled, retired)
+  explaining what strategies must or must not assume
+- A bullet about the number of concurrent CUDA versions and the driver-version
+  dependency each introduces
+- A bullet about any per-architecture versioning schemes (e.g., IBM Spyre)
+- A bullet about the authoritative Python package index
+
+**Context section** — Keep largely as-is but update the date and any version
+references so it remains accurate. The context explains _why_ the overlay
+exists; that rationale does not change with routine updates.
+
+### Step 5: Write the Updated File
+
+Write the updated content to `overlays/0017-aipcc-base-images.md` using the
+Write tool.
+
+### Step 6: Report
+
+Output a brief summary:
+
+```
+Updated overlays/0017-aipcc-base-images.md
+
+Changes:
+- [list any accelerators added, removed, or with changed status/versions]
+- [note any changes to common foundation]
+
+Repository cloned/updated: tmp/app (not tracked by git)
+```
+
+## Notes
+
+- **Trust assumption:** This skill executes `generate-platform-docs.py` from
+  `https://gitlab.com/redhat/rhel-ai/core/base-images/app.git` without
+  integrity verification. The upstream repository is assumed to be trusted and
+  not compromised. Do not run this skill against a fork or unofficial mirror.
+- `tmp/` is in `.gitignore`; the cloned repository is local only
+- The script is idempotent: run it again any time the upstream repository changes
+- Do not change the overlay `id` (0017) or `author` fields
+- Preserve Jira ticket references (e.g., AIPCC-3471) in the Fact section when
+  they are still accurate; remove them if the underlying issue is resolved

--- a/.claude/skills/update-aipcc-base-images-overlay/scripts/fetch-base-images-repo.sh
+++ b/.claude/skills/update-aipcc-base-images-overlay/scripts/fetch-base-images-repo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Fetches the AIPCC base images repository to ./tmp/app.
+# Safe to run multiple times — pulls updates if already cloned.
+
+REPO_URL="https://gitlab.com/redhat/rhel-ai/core/base-images/app.git"
+DEST_DIR="tmp/app"
+
+if [ -d "$DEST_DIR/.git" ]; then
+  echo "Repository already exists at $DEST_DIR, pulling latest changes..."
+  if ! git -C "$DEST_DIR" pull; then
+    echo "ERROR: git pull failed in $DEST_DIR" >&2
+    exit 1
+  fi
+else
+  echo "Cloning base images repository to $DEST_DIR..."
+  mkdir -p tmp
+  git clone --depth 1 "$REPO_URL" "$DEST_DIR"
+fi
+
+echo "Base images repository ready: $DEST_DIR"

--- a/overlays/0017-aipcc-base-images.md
+++ b/overlays/0017-aipcc-base-images.md
@@ -34,7 +34,7 @@ All images share:
 - **Base OS:** RHEL 9.6 (`registry.redhat.io/rhel9-6-els/rhel:9.6`)
 - **Python:** 3.12
 - **RHEL AI repo version:** 3.5
-- **Package index version:** 3.5-EA2
+- **Package index version:** 3.5
 - **Repositories:** BaseOS, AppStream, CodeReady Builder, RHELAI (EUS
   repos on even y-stream releases like 9.6)
 - **Container layout:** `/opt/app-root/` with `pip.conf` and `uv.toml`
@@ -50,11 +50,11 @@ All images share:
 |---|---|---|---|---|---|---|---|---|
 | CPU | -- | Active | 3.12 | 9.6 | Yes | Yes | Yes | Yes |
 | NVIDIA CUDA | 12.9.1 | Active | 3.12 | 9.6 | Yes | -- | -- | Yes |
-| NVIDIA CUDA | 13.0.1 | Active | 3.12 | 9.6 | Yes | -- | -- | Yes |
+| NVIDIA CUDA | 13.0.2 | Active | 3.12 | 9.6 | Yes | -- | -- | Yes |
 | NVIDIA CUDA | 13.2.1 | Active | 3.12 | 9.6 | Yes | -- | -- | Yes |
-| AMD ROCm | 7.1.1 | Active | 3.12 | 9.6 | -- | -- | -- | Yes |
+| AMD ROCm | 7.14 | Active | 3.12 | 9.6 | -- | -- | -- | Yes |
 | Intel Gaudi | 1.24.0 | Disabled | 3.12 | 9.6 | -- | -- | -- | Yes |
-| IBM Spyre | 1.2.1 | Active | 3.12 | 9.6 | -- | Yes | Yes | Yes |
+| IBM Spyre | 1.2.3 | Active | 3.12 | 9.6 | -- | Yes | Yes | Yes |
 | AWS Neuron | 2.x | In development | 3.12 | 9.6 | -- | -- | -- | Yes |
 | Google TPU | -- | In development | 3.12 | 9.6 | -- | -- | -- | Yes |
 | AMD ROCm | 6.4 | Retired | -- | -- | -- | -- | -- | -- |
@@ -97,21 +97,21 @@ build args.
   - cuSPARSELt 0.x
   - NVSHMEM 3.4.5
 
-#### CUDA 13.0.1
+#### CUDA 13.0.2
 
 - **Status:** Active
 - **Config:** `build-args/cuda13.0-el9.6-app.conf`
 - **Architectures:** aarch64, x86\_64
 - **Container:** `quay.io/aipcc/base-images/cuda-13.0-el9.6`
-- **Driver requirement:** `>=580.65.06`
+- **Driver requirement:** `>=580.95.05`
 - **Key dependencies:**
-  - NCCL 2.28.9
+  - NCCL 2.28.3
   - cuDNN 9.19.0.56
   - UCX 1.19.1
   - cuBLASMp 0.x
   - cuDSS 0.x
   - cuSPARSELt 0.x
-  - NVSHMEM 3.5.19
+  - NVSHMEM 3.4.5
 
 #### CUDA 13.2.1
 
@@ -132,10 +132,10 @@ build args.
 ### AMD ROCm
 
 - **Status:** Active
-- **Config:** `build-args/rocm7.1-el9.6-app.conf`
-- **ROCm version:** 7.1.1
+- **Config:** `build-args/rocm7.14-el9.6-app.conf`
+- **ROCm version:** 7.14
 - **Architectures:** x86\_64
-- **Container:** `quay.io/aipcc/base-images/rocm-7.1-el9.6`
+- **Container:** `quay.io/aipcc/base-images/rocm-7.14-el9.6`
 - **Key dependencies:** MIOpen, RCCL, hipBLAS, and other ROCm
   libraries are installed via vendor RPM repositories. AMD uses
   separate `amd-gpu` and `rocm` repo IDs per version.
@@ -151,12 +151,14 @@ build args.
 
 Gaudi builds are disabled because earlier versions did not support
 Python 3.12 and RHEL 9.6. Gaudi support is planned to resume in 2026.
+The Tekton push pipeline exists but triggers only on `refs/tags/gaudi-v`
+tags, not in regular CI.
 
 ### IBM Spyre
 
 - **Status:** Active
 - **Config:** `build-args/spyre-app.conf`
-- **Spyre version:** 1.2.1 (all architectures)
+- **Spyre version:** 1.2.3 (all architectures)
 - **Architectures:** ppc64le, s390x, x86\_64
 - **Container:** `quay.io/aipcc/base-images/spyre`
 - **Notes:** Spyre uses per-architecture version variables
@@ -194,7 +196,7 @@ Python 3.12 and RHEL 9.6. Gaudi support is planned to resume in 2026.
 
 ROCm 6.4 was retired in RHAI 3.5-EA1
 ([AIPCC-15426](https://issues.redhat.com/browse/AIPCC-15426)). The
-base image and Tekton pipelines were removed. ROCm 7.1.1 is the
+base image and Tekton pipelines were removed. ROCm 7.14 is the
 current supported version.
 
 ## Impact on Strategies
@@ -208,7 +210,7 @@ current supported version.
   until support resumes (planned 2026) and must not reference Gaudi as an
   available accelerator.
 - AMD ROCm 6.4 is retired; any references in strategies or RFEs must be updated
-  to ROCm 7.1.1, the current supported version.
+  to ROCm 7.14, the current supported version.
 - Three CUDA versions (12.9, 13.0, 13.2) are maintained simultaneously --
   strategies and RFEs proposing CUDA-dependent features should specify the
   minimum driver version requirement, since each version has a different minimum


### PR DESCRIPTION
## Summary

- Adds a new skill (`update-aipcc-base-images-overlay`) that refreshes
  `overlays/0017-aipcc-base-images.md` from the upstream
  `base-images/app` GitLab repository. The skill clones the repo via a
  helper shell script, runs `bin/generate-platform-docs.py` from the
  cloned copy to produce fresh accelerator tables, then rewrites the
  overlay's Fact section while preserving the human-authored Impact on
  Strategies and Context sections.
- Updates the overlay with current data from the repository:
  - NVIDIA CUDA 13.0: version 13.0.1 to 13.0.2, driver >=580.95.05, NCCL 2.28.3, NVSHMEM 3.4.5
  - AMD ROCm: 7.1.1 to 7.14 (new versioning scheme), updated config and container names
  - IBM Spyre: 1.2.1 to 1.2.3

## Test plan

- [x] Run `/update-aipcc-base-images-overlay` in this repository to verify the skill clones the repo and updates the overlay
- [x] Confirm `overlays/0017-aipcc-base-images.md` reflects current upstream versions after running the skill

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated accelerator base image versions: NVIDIA CUDA to 13.0.2, AMD ROCm to 7.14, IBM Spyre to 1.2.3, and RHEL AI Python Package Index to 3.5.
  * Enhanced Gaudi accelerator documentation with added tag-trigger configuration notes.
  * Refreshed retired-accelerator guidance to reflect ROCm 7.14 as the current supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->