### PR TITLE
Add AIPCC Ecosystem Use section to architecture summaries

### DIFF
--- a/.claude/skills/repo-to-architecture-summary/SKILL.md
+++ b/.claude/skills/repo-to-architecture-summary/SKILL.md
@@ -140,6 +140,45 @@ The intent drives the Sub-Component Details section in the output.
 
 See [Konflux Component Discovery](references/konflux-component-discovery.md) for the full procedure.
 
+### Step 3c: AIPCC Ecosystems Detection
+
+For every Konflux Dockerfile that installs Python packages (via `pip`
+or `uv`), check for indicators that the project uses the output of the
+AIPCC Ecosystems team:
+
+- References `quay.io/aipcc/base-images/*` in FROM lines
+- Uses build args (`BASE_IMAGE`, `AIPCC_IMAGE`, `FROM_IMAGE`, etc.) that may resolve to AIPCC images
+- Has filename suffixes indicating accelerator variants (`.cpu`, `.cuda*`, `.rocm*`, `.gaudi`, `.spyre`, `.neuron`, `.tpu`)
+- References AIPCC tooling paths (the string `rhaipcc`, per overlay 0017: `/usr/libexec/rhaipcc/dnf`, `/etc/rhaipcc/env`)
+
+**Always include the `## AIPCC Ecosystems Use` section when any Konflux Dockerfile installs Python packages.** The section documents both actual AIPCC usage AND the absence of AIPCC usage. Components that install Python packages but do NOT use AIPCC base images represent a gap that architects need to track. Skip this section only when no Konflux Dockerfile installs Python packages.
+
+**When AIPCC indicators are found:**
+1. Read `overlays/0017-aipcc-base-images.md` from the architecture-context repo (the repo
+   containing this skill) to get the authoritative catalog of accelerator variants,
+   their current versions, architectures, and status. Do NOT rely on cached or remembered
+   values -- always read the overlay file to get current data.
+2. For each matching Dockerfile:
+   a. Extract the exact base image reference (including SHA256 digest if present).
+   b. Match the image name or Dockerfile suffix against the variant catalog from overlay 0017
+      to determine: Accelerator type, Version, Architectures, Status.
+   c. If the image name matches an AIPCC pattern not listed in overlay 0017, document it
+      as-is with Status "Unknown" and note it may be a new or unlisted variant.
+   d. If the image is a non-AIPCC Python base, document base image; set Accelerator and
+      Status to "N/A".
+3. Check whether the Dockerfile adds pip/uv configuration beyond what the AIPCC base
+   provides, and list any additional packages installed on top.
+4. Check whether the Dockerfile calls `/usr/libexec/rhaipcc/dnf` or sources `/etc/rhaipcc/env`.
+5. Write all findings into the `## AIPCC Ecosystems Use` section.
+
+**When NO AIPCC indicators are found but Python packages are installed:**
+1. Still include the `## AIPCC Ecosystems Use` section.
+2. For each Dockerfile that installs Python packages but uses a non-AIPCC base image,
+   document the base image used and note that it does not use the AIPCC Ecosystems.
+3. State that the component must be migrated to use AIPCC base images
+   to comply with Red Hat's product security requirements for secure
+   builds regardless of whether it uses accelerator-specific libraries.
+
 ### Step 3b: Select Analysis Strategy
 
 Based on what you found in Steps 3 and 3a, select which reference doc(s) to use for deep code analysis in Step 4a:
@@ -413,8 +452,11 @@ Follow the template exactly as defined in [architecture template](references/arc
 - If a section has no data (e.g., no gRPC services), keep the heading and empty table header row, omit data rows
 - Document current behavior based on code analysis, not assumptions
 
+**AIPCC Ecosystems Use** (conditional):
+If any Konflux Dockerfile installs Python packages (via pip or uv), write the `## AIPCC Ecosystems Use` section immediately after `## Architecture Components`. Include it whether or not AIPCC base images are actually used -- documenting the absence is as important as documenting usage. Omit the section only when no Konflux Dockerfile installs Python packages.
+
 **Sub-Component Details** (multi-component repos only):
-When the component inventory from Step 3a contains multiple Konflux Dockerfiles, add a **Sub-Component Details** section after Architecture Components. Each Dockerfile-derived component gets its own `###` subsection with: intent (1-2 sentences on why it exists and when it's deployed), API routes, upstream dependencies, and configuration tables. For single-Dockerfile repos, skip this section — the Purpose section covers intent. Every sub-component MUST be analyzed — do not sample or skip any.
+When the component inventory from Step 3a contains multiple Konflux Dockerfiles, add a **Sub-Component Details** section after Architecture Components (and after AIPCC Ecosystems Use if present). Each Dockerfile-derived component gets its own `###` subsection with: intent (1-2 sentences on why it exists and when it's deployed), API routes, upstream dependencies, and configuration tables. For single-Dockerfile repos, skip this section -- the Purpose section covers intent. Every sub-component MUST be analyzed -- do not sample or skip any.
 
 When writing the intent for init containers and utility images: the Dockerfile `CMD` is the image default for standalone use. In Kubernetes, the consuming deployment typically overrides it via `command:`/`args:`. Describe the deployed behavior (what the pod actually runs), not just the image default. If the runtime command is specified in a deployment manifest within the repo (or a sibling checkout), use that. If it cannot be determined, note the Dockerfile CMD as the default and that the runtime command is set by the consuming deployment.
 

--- a/.claude/skills/repo-to-architecture-summary/references/architecture-template.md
+++ b/.claude/skills/repo-to-architecture-summary/references/architecture-template.md
@@ -21,9 +21,45 @@
 |-----------|------|---------|
 | [name] | [Go Operator / Python Service / React Frontend / etc.] | [what it does] |
 
+## AIPCC Ecosystems Use
+
+_Include this section when any Konflux Dockerfile installs Python packages (via pip or uv), whether or not AIPCC base images are actually used. Documenting the absence of AIPCC usage is as important as documenting usage -- components that install Python packages without AIPCC base images represent a gap that architects need to track. Omit this section only when no Konflux Dockerfile installs Python packages. Cross-reference with overlay 0017 (overlays/0017-aipcc-base-images.md) for base image status._
+
+### Accelerator Build Variants
+
+| Variant | Dockerfile | Base Image | Accelerator | Version | Architectures | Status |
+|---------|-----------|------------|-------------|---------|---------------|--------|
+| [variant name from overlay 0017] | [Dockerfile.konflux.cpu] | [quay.io/aipcc/base-images/... or digest-pinned ref] | [CPU / NVIDIA CUDA / AMD ROCm / Intel Gaudi / IBM Spyre / AWS Neuron / Google TPU] | [version from overlay 0017] | [architectures from overlay 0017] | [Active / Disabled / In development / Retired] |
+
+Status values (from overlay 0017):
+- **Active** -- supported and built in CI
+- **In development** -- under active development, not yet GA
+- **Disabled** -- configuration exists but builds are skipped
+- **Retired** -- removed from the repository
+
+### AIPCC Package Index
+
+_AIPCC base images ship with pip.conf and uv.toml pre-configured to use the RHEL AI Python Package Index (per overlay 0017). Document any additional pip/uv configuration or packages the component adds on top._
+
+| Scope | Details |
+|-------|---------|
+| **Uses RHEL AI PyPI** | [Yes -- inherited from AIPCC base / No] |
+| **pip.conf / uv.toml configured** | [Inherited from base image / Overridden / No] |
+| **Additional packages installed** | [List key packages added on top of base, or "None"] |
+| **Source** | [Dockerfile path:line] |
+
+### AIPCC Tooling
+
+_Document use of AIPCC-specific helper scripts and environment metadata defined in overlay 0017._
+
+| Tool / Path | Purpose | Used By |
+|-------------|---------|---------|
+| [`/usr/libexec/rhaipcc/dnf`] | [Enable vendor repos for additional RPM installs] | [Dockerfile RUN step] |
+| [`/etc/rhaipcc/env`] | [Shell variables for variant, versions, repo info] | [Entrypoint / runtime config] |
+
 ## Sub-Component Details
 
-_Include this section when the repo produces multiple deployable artifacts (multiple Konflux Dockerfiles, multiple cmd/ entry points, sidecar containers, etc.). For single-component repos, skip this section — the Purpose section covers intent._
+_Include this section when the repo produces multiple deployable artifacts (multiple Konflux Dockerfiles, multiple cmd/ entry points, sidecar containers, etc.). For single-component repos, skip this section -- the Purpose section covers intent._
 
 ### [component-name]
 

--- a/.claude/skills/repo-to-architecture-summary/references/konflux-component-discovery.md
+++ b/.claude/skills/repo-to-architecture-summary/references/konflux-component-discovery.md
@@ -40,14 +40,37 @@ For each Dockerfile, extract:
 | **Dep install commands** | How deps are fetched — hermetic vs network | `go mod download`, `pip install --require-hashes --no-deps`, `npm ci`, `pip install -r requirements.txt` (non-hermetic) |
 | **User** | Runtime user for security analysis | `USER 65532:65532`, `USER 1001` |
 
+## Step 2a: Detect AIPCC Ecosystems Usage
+
+Run these greps to identify AIPCC base images and tooling usage:
+
+```bash
+# Direct AIPCC base image references in FROM lines
+grep -rn "aipcc/base-images" --include="Dockerfile*" --include="Containerfile*" .
+
+# Build args that parameterize the base image
+grep -rn "BASE_IMAGE\|AIPCC_IMAGE\|FROM_IMAGE" --include="Dockerfile*" --include="Containerfile*" .
+
+# AIPCC helper scripts and environment metadata (paths from overlay 0017)
+grep -rn "rhaipcc" --include="Dockerfile*" --include="Containerfile*" .
+
+# Accelerator-specific build args that distinguish variants
+grep -rn "CUDA_VERSION\|ROCM_VERSION\|GAUDI_VERSION\|SPYRE_VERSION\|NEURON_VERSION" \
+  --include="Dockerfile*" --include="Containerfile*" .
+```
+
+Record any matches -- they feed into the `## AIPCC Ecosystems Use` section of the architecture output.
+
 ## Step 3: Build component inventory table
 
 Produce a table mapping each Dockerfile to a component:
 
-| Dockerfile | Component | Intent | Language | Source Dirs | Port | Entry | Base Image |
-|-----------|-----------|--------|----------|-------------|------|-------|------------|
-| `Dockerfile.konflux` | main | Primary service | Go | `cmd/`, `pkg/`, `internal/` | 8080 | `/manager` | ubi9/go-toolset → ubi9-minimal |
-| `Dockerfile.konflux.genai` | genai | Sidecar module | Go+TS | `packages/gen-ai/bff/`, `packages/gen-ai/frontend/` | 8080 | `/bff` | go-toolset + nodejs-22 → ubi9-minimal |
+| Dockerfile | Component | Intent | Language | Source Dirs | Port | Entry | Base Image | AIPCC Variant |
+|-----------|-----------|--------|----------|-------------|------|-------|------------|---------------|
+| `Dockerfile.konflux` | main | Primary service | Go | `cmd/`, `pkg/`, `internal/` | 8080 | `/manager` | ubi9/go-toolset -> ubi9-minimal | none |
+| `Dockerfile.konflux.genai` | genai | Sidecar module | Go+TS | `packages/gen-ai/bff/`, `packages/gen-ai/frontend/` | 8080 | `/bff` | go-toolset + nodejs-22 -> ubi9-minimal | none |
+
+The **AIPCC Variant** column contains the matched variant name from overlay 0017, or "none" for non-AIPCC images.
 
 **Intent values** — classify each component:
 - **Primary service**: The main binary/server the repo exists to produce
@@ -116,3 +139,4 @@ The component inventory table feeds into the architecture template:
 - **Security → FIPS Compliance**: FIPS build flags from Dockerfiles (`GOEXPERIMENT=strictfipsruntime`, `CGO_ENABLED=1`, `-tags strictfipsruntime`) MUST be written into the FIPS Compliance table. If NO FIPS flags were found in any Dockerfile, document that absence — it is architecturally significant (the component may rely on base image FIPS mode or may not be FIPS-compliant at all)
 - **Security → Build Hermeticity**: Document lock files found at each layer (RPM: `rpms.lock.yaml`, language: `go.sum`/`uv.lock`/`poetry.lock`/`Pipfile.lock`/`package-lock.json`/`yarn.lock`/`Cargo.lock`/`pixi.lock`, artifacts: `artifacts.lock.yaml`) and Hermeto (formerly cachi2) prefetch usage from the Dockerfile. Note hermeticity gaps — a missing layer means that layer's deps are not reproducibly locked. Also note if the branch is upstream (lock files often absent) vs downstream release (lock files added during hardening)
 - **Security**: runtime user, base image provenance
+- **AIPCC Ecosystems Use** section: populate when any Konflux Dockerfile installs Python packages (via pip or uv), whether or not AIPCC base images are used. Omit only when no Konflux Dockerfile installs Python packages.

--- a/.claude/skills/repo-to-architecture-summary/scripts/validate_architecture.py
+++ b/.claude/skills/repo-to-architecture-summary/scripts/validate_architecture.py
@@ -48,6 +48,15 @@ REQUIRED_H3_SUBSECTIONS = {
     ],
 }
 
+# Optional H2 sections defined by the skill instructions (conditional on repo type).
+# These should not trigger warnings when present.
+OPTIONAL_H2_SECTIONS = [
+    "AIPCC Ecosystems Use",
+    "Sub-Component Details",
+    "Deployment Manifests",
+    "Architectural Analysis",
+]
+
 REQUIRED_METADATA_FIELDS = [
     "Repository",
     "Version",
@@ -59,22 +68,71 @@ REQUIRED_METADATA_FIELDS = [
 
 EXPECTED_TABLE_HEADERS = {
     "Architecture Components": ["Component", "Type", "Purpose"],
-    "Custom Resource Definitions (CRDs)": ["Group", "Version", "Kind", "Scope", "Purpose"],
-    "HTTP Endpoints": ["Path", "Method", "Port", "Protocol", "Encryption", "Auth", "Purpose"],
+    "Custom Resource Definitions (CRDs)": [
+        "Group",
+        "Version",
+        "Kind",
+        "Scope",
+        "Purpose",
+    ],
+    "HTTP Endpoints": [
+        "Path",
+        "Method",
+        "Port",
+        "Protocol",
+        "Encryption",
+        "Auth",
+        "Purpose",
+    ],
     "gRPC Services": ["Service", "Port", "Protocol", "Encryption", "Auth", "Purpose"],
     "External Dependencies": ["Component", "Version", "Required", "Purpose"],
     "Internal Platform Dependencies": ["Component", "Interaction Type", "Purpose"],
-    "Services": ["Service Name", "Type", "Port", "Target Port", "Protocol", "Encryption", "Auth", "Exposure"],
-    "Ingress": ["Name", "Type", "Hosts", "Port", "Protocol", "Encryption", "TLS Mode", "Exposure"],
+    "Services": [
+        "Service Name",
+        "Type",
+        "Port",
+        "Target Port",
+        "Protocol",
+        "Encryption",
+        "Auth",
+        "Exposure",
+    ],
+    "Ingress": [
+        "Name",
+        "Type",
+        "Hosts",
+        "Port",
+        "Protocol",
+        "Encryption",
+        "TLS Mode",
+        "Exposure",
+    ],
     "Egress": ["Destination", "Port", "Protocol", "Encryption", "Auth", "Purpose"],
     "RBAC - Cluster Roles": ["Role Name", "API Group", "Resources", "Verbs"],
     "RBAC - Role Bindings": ["Binding Name", "Namespace", "Role", "Service Account"],
     "Secrets": ["Secret Name", "Type", "Purpose", "Provisioned By", "Auto-Rotate"],
-    "Authentication & Authorization": ["Endpoint", "Methods", "Auth Mechanism", "Enforcement Point", "Policy"],
-    "Integration Points": ["Component", "Interaction Type", "Port", "Protocol", "Encryption", "Purpose"],
+    "Authentication & Authorization": [
+        "Endpoint",
+        "Methods",
+        "Auth Mechanism",
+        "Enforcement Point",
+        "Policy",
+    ],
+    "Integration Points": [
+        "Component",
+        "Interaction Type",
+        "Port",
+        "Protocol",
+        "Encryption",
+        "Purpose",
+    ],
     "Recent Changes": ["Version", "Date", "Changes"],
     "Files Analyzed": ["File", "Lines", "Sections Informed"],
-    "Grep/Search Results Used": ["Search Pattern", "Files Matched", "Sections Informed"],
+    "Grep/Search Results Used": [
+        "Search Pattern",
+        "Files Matched",
+        "Sections Informed",
+    ],
 }
 
 
@@ -82,7 +140,7 @@ def _parse_headings(text: str) -> list[tuple[int, str]]:
     """Extract (level, title) for all markdown headings."""
     headings = []
     for line in text.splitlines():
-        m = re.match(r'^(#{1,6})\s+(.+)$', line)
+        m = re.match(r"^(#{1,6})\s+(.+)$", line)
         if m:
             headings.append((len(m.group(1)), m.group(2).strip()))
     return headings
@@ -97,16 +155,16 @@ def _parse_tables(text: str) -> dict[str, list[str]]:
     current_section = None
 
     for line in text.splitlines():
-        m = re.match(r'^(#{2,3})\s+(.+)$', line)
+        m = re.match(r"^(#{2,3})\s+(.+)$", line)
         if m:
             current_section = m.group(2).strip()
             # Strip "Flow N:" prefix for data flows
-            current_section = re.sub(r'^Flow \d+:\s*', '', current_section)
+            current_section = re.sub(r"^Flow \d+:\s*", "", current_section)
             continue
 
         if current_section and current_section not in tables:
-            if line.strip().startswith('|') and '---' not in line:
-                cols = [c.strip() for c in line.strip().strip('|').split('|')]
+            if line.strip().startswith("|") and "---" not in line:
+                cols = [c.strip() for c in line.strip().strip("|").split("|")]
                 cols = [c for c in cols if c]
                 if cols:
                     tables[current_section] = cols
@@ -119,13 +177,13 @@ def _parse_metadata_fields(text: str) -> list[str]:
     fields = []
     in_metadata = False
     for line in text.splitlines():
-        if re.match(r'^##\s+Metadata\s*$', line):
+        if re.match(r"^##\s+Metadata\s*$", line):
             in_metadata = True
             continue
-        if in_metadata and re.match(r'^##\s+', line):
+        if in_metadata and re.match(r"^##\s+", line):
             break
         if in_metadata:
-            m = re.match(r'^-\s+\*\*(.+?)\*\*:', line)
+            m = re.match(r"^-\s+\*\*(.+?)\*\*:", line)
             if m:
                 fields.append(m.group(1))
     return fields
@@ -166,12 +224,12 @@ def validate(path: str) -> tuple[list[str], list[str]]:
     expected_order = [s for s in REQUIRED_H2_SECTIONS if s in found_required]
     if found_required != expected_order:
         errors.append(
-            f"Sections out of order. Expected: {expected_order}, "
-            f"got: {found_required}"
+            f"Sections out of order. Expected: {expected_order}, got: {found_required}"
         )
 
     # Warn on extra H2 sections
-    extra_h2 = [s for s in h2s if s not in REQUIRED_H2_SECTIONS]
+    known_h2 = set(REQUIRED_H2_SECTIONS) | set(OPTIONAL_H2_SECTIONS)
+    extra_h2 = [s for s in h2s if s not in known_h2]
     for section in extra_h2:
         warnings.append(f"Unexpected section: ## {section} (not in template)")
 

--- a/overlays/0017-aipcc-base-images.md
+++ b/overlays/0017-aipcc-base-images.md
@@ -17,9 +17,11 @@ superseded_by: null
 ## Fact
 
 The AIPCC base images provide RHEL-based application containers with
-runtime dependencies for hardware accelerators used in AI workloads.
-Downstream teams extend these images by installing Python wheels and
-additional packages to create product containers (e.g., vLLM, InstructLab).
+runtime dependencies for hardware accelerators used in AI
+workloads. The images also provide access to versions of python
+packages built in Red Hat's secure build pipelines.  Downstream teams
+extend these images by installing Python wheels and additional
+packages to create product containers (e.g., vLLM, InstructLab).
 
 Images follow a layout similar to
 [s2i-base-containers](https://github.com/sclorg/s2i-base-container)


### PR DESCRIPTION
## Summary

- Add AIPCC Ecosystem Use section to the `repo-to-architecture-summary` skill with detection steps, template tables for accelerator build variants, package index usage, and AIPCC tooling
- Update Konflux component discovery to include AIPCC ecosystem detection (Step 2a) and an AIPCC Variant column in the component inventory
- Update the architecture validation script to recognize optional H2 sections (AIPCC Ecosystem Use, Sub-Component Details, Deployment Manifests, Architectural Analysis) without warnings
- Update overlay 0017 to document the secure Python package index provided by AIPCC base images

## Test plan

- [x] Tested skill against fms-guardrails-orchestrator (no Python packages — section correctly omitted)
- [x] Tested skill against kserve (Go and Python — AIPCC detection exercised)
- [x] Tested skill against feast (Go, Python, and TypeScript — AIPCC detection exercised)
- [x] Run `validate_architecture.py` against architecture files with and without the AIPCC Ecosystem Use section to verify no spurious warnings or regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AIPCC ecosystem detection for Konflux Dockerfiles and conditional generation of “AIPCC Ecosystem Use” documentation.
  * Extended component discovery with an “AIPCC Variant” indicator, including non-AIPCC cases.

* **Documentation**
  * Updated the architecture template to insert “AIPCC Ecosystem Use” after “Architecture Components” and moved “Sub-Component Details” accordingly, including guidance for build variants, package index use, and AIPCC tooling.

* **Bug Fixes**
  * Improved architecture document validation by allowing optional H2 sections without warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->