### PR TITLE
feat(overlay-0014): enrich with KServe deprecation landscape, AIPCC constraints, and dependency matrix

### DIFF
--- a/overlays/0014-model-runtimes-team-architecture.md
+++ b/overlays/0014-model-runtimes-team-architecture.md
@@ -310,10 +310,13 @@ Source: `opendatahub-io/openvino_model_server` README; `odh-model-controller/con
 - **Template**: `mlserver-runtime-template` (`mlserver-template.yaml` in `config/runtimes/`)
 - **Image**: `registry.redhat.io` (sha256 pinned in CSV `relatedImages`)
 - **Supported formats**: LightGBM, ONNX, Sklearn (scikit-learn), XGBoost
-- **GPU support**: Via `onnxruntime-gpu` Python package swap:
-  - Replace `onnxruntime` with `onnxruntime-gpu` in container
-  - Configure CUDA/TensorRT execution providers
-  - No separate container image needed (unlike vLLM's per-accelerator images)
+- **GPU support**: Requires separate container image on `aipcc/cuda` base:
+  - CPU base image (`aipcc/cpu`) does **NOT** include CUDA runtime libraries (`libcudart.so`)
+  - `onnxruntime-gpu` will crash immediately on CPU base: `OSError: libcudart.so.12: cannot open shared object file`
+  - Pattern: new Konflux pipeline producing `mlserver-onnx-gpu` image on `aipcc/cuda` base
+  - Follows same model as vLLM (separate purpose-built images per accelerator)
+  - CPU image remains unchanged — **not** a hybrid/unified build (CUDA payload adds ~500MB–1GB, unacceptable for air-gapped CPU-only deployments)
+  - **AIPCC dependency**: `onnxruntime-gpu` must be available in the AIPCC CUDA collection. New package onboarding or restoration follows the standard AIPCC process (1–3 weeks). Strategy timelines must account for this.
 - **Critical upstream context**:
   - Upstream community (`SeldonIO/MLServer` on GitHub) is **dead/orphaned**
   - Seldon (the parent company/sponsor) has been **liquidated**
@@ -607,6 +610,333 @@ Source: `utilities/serving_runtime.py`, `utilities/inference_utils.py`, `tests/m
   probe testing (readiness + liveness), type-safe assertions
 - Triton migration to external routes is a pending modernization item
 - OVMS/MLServer may adopt fuzzy validation for cross-hardware GPU testing
+
+### AIPCC Base Image Architecture (Serving Runtimes)
+
+RHOAI serving runtime container images are built on top of **AIPCC (AI Platform Common Components)** base images. These bases determine the hardware capability ceiling of every image built on them. All Python dependencies must be sourced from the AIPCC pip index — **no direct pypi.org access is available in hermetic builds**.
+
+#### Base Image Variants
+
+| Base Image | Contents | Purpose | GPU Drivers |
+|---|---|---|---|
+| `aipcc/cpu` | Python runtime, OS packages, no CUDA | CPU-only inference (predictive + LLM CPU variants) | None |
+| `aipcc/cuda` | Python runtime, OS packages, CUDA toolkit + `libcudart.so` | NVIDIA GPU inference | CUDA runtime libraries included |
+| `aipcc/rocm` *(future)* | Python runtime, OS packages, ROCm toolkit | AMD GPU inference (not yet used for predictive runtimes) | ROCm runtime libraries |
+
+#### Key Architectural Constraints
+
+- **Mutually exclusive bases** — `aipcc/cpu` and `aipcc/cuda` are separate, non-interchangeable base images. You **cannot** pip-install GPU support into a CPU base. The CUDA runtime libraries (`libcudart.so`, `libcublas.so`, etc.) are system-level shared objects that must exist in the base image.
+
+- **Separate image pattern** — If a runtime needs GPU acceleration, it needs a **separate image** built on `aipcc/cuda`. This is the same pattern vLLM follows: `vllm-cuda-runtime` is a distinct image from any CPU variant. MLServer GPU (ONNX) must follow the same pattern.
+
+- **Image size implications** — CUDA toolkit adds approximately 500MB–1GB to the image. Hybrid images (shipping both CPU and CUDA in one image) are **NOT acceptable** for air-gapped/disconnected deployments where image pull size is a hard constraint.
+
+- **ROCm for predictive runtimes** — If AMD GPU acceleration is needed for predictive runtimes in the future, a new `aipcc/rocm` base would be required. This is not currently planned for MLServer or OVMS.
+
+- **Hermetic build mandate** — All Python packages must be built and served from the AIPCC pip index with SHA256-pinned hashes. No `pip install` from pypi.org at build time. This is a security directive, not a preference.
+
+#### AIPCC Package Onboarding Process
+
+New Python dependencies require AIPCC onboarding before they can be consumed in any serving runtime image. This is a **1–3 week lead time** with the following steps:
+
+1. Self-service pipeline submission (package request Jira ticket in AIPCC project)
+2. Builder onboarding (AIPCC team configures source resolver)
+3. Probe tests and build verification (AutoQA across all architecture variants)
+4. Pipeline integration and QE validation
+5. Production promotion
+
+**Strategies proposing new Python dependencies MUST factor in this lead time.** It is not possible to "just add" a package at development time.
+
+Source: AIPCC onboarding process; RHOAIENG-37768 (MLServer full integration journey); AIPCC-18708 (kserve-storage onboarding example).
+
+#### Runtime-Specific AIPCC Status
+
+| Runtime | Base Image | Hermetic Build Status | Automation | Notes |
+|---|---|---|---|---|
+| MLServer | `quay.io/aipcc/base-images/cpu` | **GA — fully hermetic** | Renovate auto-tracks base image; GitHub Actions generates hash-pinned requirements.txt | All 5 plugins (mlserver, lightgbm, onnx, sklearn, xgboost) onboarded |
+| OVMS | UBI9 + upstream Bazel build | **Not hermetic** — Bazel + TF dependency incompatible with Konflux model | None (non-hermetic today) | Hermetic build pending upstream TensorFlow removal from OpenVINO |
+| vLLM (all variants) | RHAIIS build (AIPCC infrastructure) | **GA** — built by AIPCC/RHAIIS team | RHOAI consumes via image override in operator CSV | RHOAI does **NOT** build vLLM images; they are consumed from `registry.redhat.io/rhaii/<image>` |
+| KServe Storage Initializer | AIPCC base (in progress) | **In progress** | Packages in review (kserve-storage, hdfs, krbcontext, requests-kerberos) | modelscope has security audit concerns |
+
+Source: RHOAIENG-67702 (OVMS hermetic build tracker); RHOAIENG-37768 (MLServer AIPCC integration); RHOAIENG-52861 (Renovate); RHOAIENG-66923 (vLLM consumption).
+
+#### vLLM Image Consumption Model
+
+RHOAI **does not build** vLLM images. All vLLM runtime images are built by the RHAIIS team using AIPCC infrastructure and consumed by RHOAI through image reference overrides in the operator CSV.
+
+| Variant | Registry Path | Status |
+|---|---|---|
+| vLLM CUDA | `registry.redhat.io/rhaii/odh-vllm-rhel9` | GA |
+| vLLM ROCm | `registry.redhat.io/rhaii/odh-vllm-rocm-rhel9` | GA |
+| vLLM Spyre | `registry.redhat.io/rhaii/odh-vllm-spyre-rhel9` | GA (x86, s390x, ppc64le) |
+| vLLM CPU | `registry.redhat.io/rhaii/odh-vllm-cpu-rhel9` | Tech Preview |
+| vLLM Gaudi | `registry.redhat.io/rhaii/odh-vllm-gaudi-rhel9` | GA |
+| vLLM-Omni | AIPCC base + Konflux | Dev Preview (multi-modal) |
+
+Source: RHOAIENG-66923; RHOAIENG-53009; RHOAIENG-52392.
+
+#### Anti-Patterns for Strategy Generation
+
+Strategies MUST NOT propose:
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| `pip install <package>` from pypi.org | Hermetic builds have no internet access; all wheels must come from AIPCC index |
+| "Build vLLM from source" or "customize vLLM image" | vLLM images are consumed from RHAIIS; RHOAI has no vLLM build pipeline |
+| "Use upstream OVMS directly" | Must use `odh-openvino-model-server` with Red Hat patches and (eventually) AIPCC dependencies |
+| "Switch base image to Ubuntu/Alpine/custom" | All serving runtime base images must come from AIPCC or UBI per security directive |
+| "Add new Python dependency" without AIPCC lead time | Onboarding takes 1–3 weeks; strategies must account for this in timeline |
+| "Use OVMS hermetic build" today | OVMS hermetic build is **not yet available** — Bazel + TensorFlow dependency prevents Konflux hermetic model |
+
+Source: AIPCC hermetic build mandate; security directive 2026; RHOAIENG-67702.
+
+#### When a New Konflux Pipeline Is Required
+
+| Scenario | New Konflux Pipeline? | Rationale |
+|---|---|---|
+| New image on a different base (e.g., `mlserver-onnx-gpu` on `aipcc/cuda`) | **Yes** | Different base image = different build pipeline |
+| New architecture variant of existing image (e.g., ppc64le build) | **Yes** | Different build target architecture |
+| Adding a Python package to an existing image on same base | No | Modify existing Dockerfile/pipeline |
+| Updating base image version (e.g., `aipcc/cpu:3.4` → `aipcc/cpu:3.5`) | No | Existing pipeline, updated FROM |
+| Adding a new model format backend to existing runtime | No | Same image, same base, same pipeline |
+
+Source: AIPCC base image specification; Konflux pipeline architecture; vLLM multi-image pattern.
+
+### Cross-Team Dependency Decision Matrix
+
+This matrix defines, for each Model Runtimes action, whether other teams require PRs or code changes. Use this when writing or reviewing strategies to identify true dependencies.
+
+| Model Runtimes Action | Dashboard Team | KServe/Platform Team | ODH Model Controller Team | Release Engineering |
+|---|---|---|---|---|
+| Add new ClusterServingRuntime template | No (annotation discovery) | No | No (auto-detected) | No |
+| Add GPU variant of existing runtime | No | No (HardwareProfile is generic) | No | Yes (new Konflux pipeline if new base image) |
+| Enable multi-model serving on a runtime | No (template auto-appears) | No (KServe is model-count agnostic) | No (V2 path routing is passthrough) | No |
+| Add new model format to existing runtime | No | No | No | No (same image) |
+| Change inference protocol (v1→v2) | Maybe (protocol display) | No | No | No |
+| Add new storage backend type | No | Maybe (if new storage initializer needed) | Maybe (Connection API extension) | No |
+| Add new autoscaling pattern | No | No | Yes (KEDA ScaledObject type) | No |
+| Add OOTB template for vendor runtime | No | No | No | Yes (CSV `relatedImages` entry) |
+| Ship new image (new accelerator) | No | No | No | Yes (new Konflux pipeline) |
+| Add new Python dependency to runtime | No | No | No | **Yes** (AIPCC onboarding: 1–3 weeks lead time) |
+
+#### Explanatory Notes
+
+- **"No" means zero PRs needed** from that team — the action is fully self-contained within Model Runtimes (or Model Runtimes + Release Engineering).
+- **Dashboard discovers runtimes via annotation** — the `opendatahub.io/dashboard: "true"` annotation on a ServingRuntime/ClusterServingRuntime template causes it to appear in the Dashboard UI automatically. No Dashboard code changes are needed.
+- **HardwareProfile webhook is generic** — it injects GPU resource limits (`nvidia.com/gpu`, `amd.com/gpu`, etc.) based on the user's HardwareProfile selection. It works with ANY runtime without per-runtime configuration. Adding a new GPU-enabled runtime template does **not** require HardwareProfile changes.
+- **KServe controller is model-count agnostic** — it manages the Deployment/Service/Route lifecycle for an InferenceService. It does not inspect or care how many models are loaded inside the container. Multi-model is transparent to KServe.
+- **ODH Model Controller V2 path routing passes through** — request routing to the runtime container does not inspect model count. Multi-model path routing (e.g., `/v2/models/{name}/infer`) is handled by the runtime itself (e.g., MLServer repository mode), not the controller.
+- **AIPCC/Release Engineering lead time** — Adding a new Python dependency is NOT instant. Package onboarding (1–3 weeks) involves builder setup, probe testing across all architecture variants, QE validation, and production promotion. Strategies must account for this in their timelines.
+
+Source: `odh-model-controller/architecture.md`; Dashboard annotation scanning logic; `rhods-operator` HardwareProfile webhook; KServe controller InferenceService reconciliation; AIPCC onboarding process.
+
+### KServe Deprecation & Multi-Model Landscape
+
+Critical context for any strategy involving multi-model serving, TrainedModel CRD, kserve-agent, ModelMesh, or deployment mode selection.
+
+#### KServe Community Health
+
+| Attribute | Value |
+|---|---|
+| CNCF Maturity | **Incubating** (accepted September 2025) |
+| Health Score (LFX) | **82/100 (Excellent)** |
+| GitHub Stars | 5,575 (+31% YoY) |
+| Total Contributors | 350+ (+29% YoY) |
+| Contributing Organizations | 610 (+39% YoY) |
+| Total Releases | 56 (accelerating) |
+
+**Red Hat is the largest single-company contributor:** 6 of 16 maintainers (including 1 Project Lead: Yuan Tang, 1 Approver: Jooho Lee, 4 Reviewers). This gives Red Hat strongest single-company influence on upstream direction — relevant for strategy feasibility when proposing features that need upstream changes.
+
+Source: https://github.com/kserve/kserve/blob/master/MAINTAINERS.md; https://www.cncf.io/projects/kserve/
+
+#### KServe Release Cadence (Accelerating)
+
+| Version | Date | Cycle | Theme |
+|---|---|---|---|
+| v0.19.0 | 2026-06-14 | ~6 weeks | LLMInferenceService maturation |
+| v0.18.0 | 2026-04-29 | ~6 weeks | LoRA reconciliation, autoscaling |
+| v0.17.0 | 2026-03-13 | ~4.5 months | LLMInferenceService webhook |
+| v0.16.0 | 2025-11-03 | ~5 months | LLMInferenceService CRD introduction |
+| v0.15.0 | 2025-05-27 | ~5 months | GenAI serving, model caching |
+
+**6 releases in 7 months** (v0.15 → v0.19). Cadence accelerated from ~5 months to ~6 weeks, driven by rapid LLMInferenceService development.
+
+Source: https://github.com/kserve/kserve/releases
+
+#### TrainedModel CRD — **DO NOT USE**
+
+| Attribute | Value |
+|---|---|
+| API | `serving.kserve.io/v1alpha1` — stuck at alpha since 2021 |
+| Last meaningful code change | PR [#3758](https://github.com/kserve/kserve/pull/3758) — bug fix only, no feature work |
+| Active development | **None** — maintainer confirmed: "no active development on TrainedModel" |
+| Upstream roadmap | Explicitly states: *"Deprecate TrainedModel CRD"* |
+| RHOAI integration | ZERO references in `odh-model-controller`, `odh-dashboard`, or `rhods-operator` |
+| RawDeployment mode | TrainedModel reconciliation is **NOT functional** |
+| Open issues (unresolved since 2021) | [#1589](https://github.com/kserve/kserve/issues/1589), [#1575](https://github.com/kserve/kserve/issues/1575) |
+
+The replacement is NOT a single new CRD but rather integrating multi-model capabilities directly into InferenceService and LLMInferenceService:
+
+| Use Case | Old (TrainedModel) | New Approach |
+|---|---|---|
+| Multiple models on one GPU | TrainedModel + kserve-agent | LLMInferenceService with LoRA adapters |
+| Dynamic model loading | TrainedModel controller | Not yet implemented for InferenceService |
+| High-density model serving | TrainedModel + ModelMesh | No direct replacement (ModelMesh **ARCHIVED**) |
+
+Source: https://github.com/kserve/kserve/blob/master/ROADMAP.md; PR #3758 maintainer comment; KServe GitHub issues.
+
+#### ModelMesh — **ARCHIVED**
+
+| Attribute | Value |
+|---|---|
+| Upstream status | **Archived** (kserve/modelmesh repository) |
+| Archive date | **February 2025** |
+| Removed from KServe Helm chart | PR [#4243](https://github.com/kserve/kserve/pull/4243), merged 2025-02-16 |
+| Reason | "ModelMesh is no longer actively developed" — maintainer confirmed "maintenance mode" |
+| RHOAI status | **Deprecated since RHOAI 2.19**; removal required for RHOAI 3.x upgrade |
+| Migration path | ModelMesh → Standard (RawDeployment) mode |
+| ODH fork | [opendatahub-io/modelmesh-serving](https://github.com/opendatahub-io/modelmesh-serving) — some continued work, but no upstream maintainer engagement |
+
+**Do NOT propose ModelMesh as an alternative for any serving strategy.** It is archived upstream with no path to revival.
+
+Source: https://github.com/kserve/kserve/pull/4243; https://github.com/kserve/modelmesh; https://github.com/kserve/modelmesh-serving/issues/542
+
+#### kserve-agent Sidecar — **NOT Compatible with RHOAI**
+
+- `kserve-agent` imports `knative.dev/serving/pkg/queue` — a Knative Serving library dependency
+- Injection is triggered by TrainedModel CRs in **Serverless mode only**
+- RHOAI uses RawDeployment exclusively → kserve-agent injection preconditions are **never met**
+- Not validated, not tested, not supported in RHOAI
+
+Source: `kserve-agent` source code import analysis; RHOAI RawDeployment-only architecture.
+
+#### LLMInferenceService — Strategic Future (v0.16 → v0.19)
+
+LLMInferenceService is the purpose-built CRD for GenAI workloads, under rapid active development:
+
+| Feature | Version Introduced | Status |
+|---|---|---|
+| LLMInferenceService CRD | v0.16 (Nov 2025) | GA-quality in v0.18+ |
+| LoRA adapter support | v0.16, matured v0.18+ | **Implemented** — per-request adapter selection with ~1-5ms overhead |
+| Disaggregated prefill/decode | v0.17+ | Active development |
+| Multi-node inference (LWS-based) | v0.16+ | **Implemented** |
+| Endpoint Picker (EPP) / intelligent routing | v0.17+ | **Implemented** |
+| KV-cache offloading | v0.18+ | Active development |
+| llm-d integration | v0.18+ | Active development (Red Hat co-lead) |
+
+**Key insight:** Multi-model for LLMs is solved via LoRA adapters in LLMInferenceService. TrainedModel-style approaches are obsolete for LLM use cases.
+
+Source: https://kserve.github.io/website/docs/next/concepts/architecture/control-plane-llmisvc; https://github.com/kserve/kserve/releases
+
+#### InferenceGraph — **Alpha, No Graduation Timeline**
+
+| Attribute | Value |
+|---|---|
+| API Version | `serving.kserve.io/v1alpha1` |
+| Maturity | **Alpha** — not recommended for production |
+| Router Types | Sequence, Switch, Ensemble, Splitter |
+| RawDeployment support | Added v0.16 (previously Serverless-only) |
+| Graduation timeline | **None committed** — "Graduate InferenceGraph" is a roadmap objective with all items "Planned" |
+
+Planned but not implemented: replica/concurrency control, distributed tracing, gRPC support, standalone Transformer, traffic mirroring.
+
+Source: https://github.com/kserve/kserve/blob/master/ROADMAP.md (Objective 4); https://kserve.github.io/website/docs/next/model-serving/inferencegraph/overview
+
+#### RawDeployment (Standard Mode) Limitations
+
+RHOAI uses RawDeployment exclusively. The following features are **Serverless-only** and **NOT available** in RHOAI:
+
+| Feature | Serverless (Knative) | Standard (RawDeployment) | Why |
+|---|---|---|---|
+| **Scale-to-zero** | Yes | **Not supported** | Requires Knative Activator to buffer requests and wake pods |
+| **Scale-from-zero** | Yes | Not supported | Requires Knative queue proxy first-request detection |
+| **Request-based autoscaling** (RPS/concurrency) | Yes (KPA) | Only CPU/Memory HPA | KPA tracks per-pod concurrency via queue proxy |
+| **Revision-based rollback** | Yes | Not supported | Knative maintains immutable revisions; Standard uses regular Deployments |
+| **Request queuing** | Yes (Queue proxy) | Not available | Requests dropped if pods aren't ready |
+| **Concurrency limiting** | Yes (containerConcurrency) | Not available | No queue proxy sidecar |
+| **Canary traffic splitting** | Yes | Added v0.16 (Gateway API) | Functional but newer, less mature |
+
+**RawDeployment advantages:** No cold start, multiple volume mounts, simpler networking (no Istio), lower resource overhead, better for GPU workloads.
+
+Source: https://kserve.github.io/website/docs/install/dependencies; https://kserve.github.io/website/docs/concepts/architecture/control-plane
+
+#### Correct Multi-Model Path for RHOAI (Predictive Workloads)
+
+- MLServer ships with built-in repository mode (`SchemalessModelRepository`)
+- `multiModel: true` in ServingRuntime spec enables multi-model at KServe level
+- **V2 Repository API**: `POST /v2/repository/models/{name}/load|unload` for dynamic model management
+- **Shared PVC** (`pvc://`) is a KServe-native storage scheme — no custom storage initializer needed
+- **No kserve-agent, no TrainedModel CRD, no Platform/KServe controller changes** — template-only change
+- Dashboard annotations: `opendatahub.io/modelServingSupport: '["multi"]'`
+- Template auto-appears in Dashboard via annotation discovery (no Dashboard code changes)
+- Triton also natively supports multi-model via its model repository when deployed as a custom ServingRuntime
+
+Source: MLServer `SchemalessModelRepository` implementation; KServe `multiModel` spec field; V2 inference protocol specification; RHAISTRAT-2011 analysis.
+
+### Serving Runtime Template Catalog (Existing + Planned)
+
+Comprehensive reference of all RHOAI serving runtime templates — both existing and planned.
+
+| Template Name | Runtime | Accelerator | Model Formats | Multi-Model | Image Base | Pipeline |
+|---|---|---|---|---|---|---|
+| `ovms-kserve-template` | OVMS | Intel GPU / CPU | OpenVINO IR, ONNX, TF SavedModel, PaddlePaddle, PyTorch | No | `aipcc/cpu` | Existing |
+| `mlserver-template` | MLServer | CPU only | LightGBM, ONNX, Sklearn, XGBoost | No (current) | `aipcc/cpu` | Existing |
+| `mlserver-multi-model-template` | MLServer | CPU only | Same as above | **Yes** (repository mode) | `aipcc/cpu` | **Planned** |
+| `mlserver-onnx-gpu-template` | MLServer | NVIDIA GPU | ONNX only | No | `aipcc/cuda` | **Planned** |
+| `vllm-cuda-runtime-template` | vLLM | NVIDIA GPU | LLM (all vLLM-supported) | N/A (LLM) | `aipcc/cuda` | Existing |
+| `vllm-rocm-runtime-template` | vLLM | AMD GPU | LLM | N/A | RHAII ROCm base | Existing |
+| `vllm-gaudi-runtime-template` | vLLM | Intel Gaudi | LLM | N/A | RHAII Gaudi base | Existing |
+| `vllm-spyre-x86-runtime-template` | vLLM | IBM Spyre | LLM | N/A | IBM Spyre base | Existing |
+| `vllm-cpu-x86-runtime-template` | vLLM | x86 CPU | LLM | N/A | IBM CPU base | Existing |
+| `vllm-cpu-power-runtime-template` | vLLM | IBM Power CPU | LLM | N/A | IBM Power base | Existing |
+| `vllm-cpu-z-runtime-template` | vLLM | IBM Z CPU | LLM | N/A | IBM Z base | Existing |
+| *(none — custom CR)* | Triton | NVIDIA GPU | TensorRT, TF, ONNX, PyTorch, XGBoost, Python, FIL, DALI, Keras | **Yes (native)** — model repository with dynamic load/unload | NVIDIA vendor | N/A (not shipped) |
+
+#### Template Catalog Notes
+
+- **"Planned" templates** are tracked in RHAISTRAT-1868 (GPU) and RHAISTRAT-2011 (multi-model).
+- Template YAML lives in `odh-model-controller/config/runtimes/`.
+- Each template requires: name, annotations (`opendatahub.io/dashboard`, `opendatahub.io/ootb`, `opendatahub.io/apiProtocol`), container spec, supported model formats, protocol versions.
+- Adding a template is a **Model Runtimes-only operation** — see Cross-Team Dependency Decision Matrix above.
+- Triton is Tested & Verified only; it has no platform template and is not shipped via `relatedImages`. However, Triton **natively supports multi-model** via its model repository — customers deploying Triton as a custom runtime can load multiple models. Red Hat supports the deployment/integration layer for this use case.
+
+Source: `odh-model-controller/config/runtimes/`; RHAISTRAT-1868; RHAISTRAT-2011.
+
+## Impact on Strategies — Additional Corrections
+
+These supplement the dependency corrections and scope boundaries above.
+
+**FALSE**: "Multi-model serving requires TrainedModel CRD and kserve-agent"
+- **TRUTH**: TrainedModel is on upstream deprecation path (no active development since 2021, stuck at alpha); kserve-agent requires Knative (not available in RHOAI RawDeployment). Use MLServer repository mode instead.
+- Source: KServe ROADMAP.md; kserve-agent source code imports; PR #3758 maintainer confirmation.
+
+**FALSE**: "GPU support can be added via package swap in existing CPU container image"
+- **TRUTH**: CPU base image (`aipcc/cpu`) does not include CUDA runtime libraries. A separate image on `aipcc/cuda` base is required. `onnxruntime-gpu` will crash with `OSError: libcudart.so.12: cannot open shared object file` on a CPU base.
+- Source: AIPCC base image specification; `onnxruntime-gpu` runtime dependency on `libcudart.so`.
+
+**FALSE**: "KServe/Platform team work is needed for multi-model support"
+- **TRUTH**: KServe controller is model-count agnostic. It manages Deployment lifecycle without inspecting the model count inside the container. Multi-model is transparent to KServe.
+- Source: KServe controller source; InferenceService reconciliation does not reference model count.
+
+**FALSE**: "Dashboard team needs to build a multi-model management UI for this to work"
+- **TRUTH**: New templates auto-appear in Dashboard via annotation discovery (`opendatahub.io/dashboard: "true"`). The bounded gap is that the deploy form is single-model optimized; CLI/kubectl works immediately without Dashboard changes. Dashboard UX enhancement for multi-model is a follow-on improvement, **not** a blocker.
+- Source: Dashboard annotation scanning; deploy form UX is enhancement, not blocker.
+
+**FALSE**: "We can build vLLM images ourselves"
+- **TRUTH**: vLLM images are built by the RHAIIS team using AIPCC infrastructure and consumed by RHOAI via image reference overrides in the operator CSV (`registry.redhat.io/rhaii/<image>`). RHOAI has no vLLM build pipeline and strategies MUST NOT propose building vLLM from source.
+- Source: RHOAIENG-66923; RHOAIENG-53009; RHOAIENG-52392.
+
+**FALSE**: "Adding a new Python package is a simple pip install"
+- **TRUTH**: Hermetic builds have no internet access. All Python packages must be onboarded to AIPCC (1–3 week lead time: self-service submission → builder onboarding → probe tests → QE → prod promotion). No direct pypi.org access at build time.
+- Source: AIPCC hermetic build mandate; RHOAIENG-37768 integration timeline; AIPCC-18708 onboarding example.
+
+**FALSE**: "ModelMesh is a viable alternative for multi-model serving"
+- **TRUTH**: ModelMesh was **archived upstream in February 2025**. It was removed from the KServe Helm chart (PR #4243, merged 2025-02-16). It is deprecated in RHOAI since 2.19 and removal is required for RHOAI 3.x. There is no upstream maintenance or development.
+- Source: https://github.com/kserve/modelmesh; https://github.com/kserve/kserve/pull/4243.
+
+**FALSE**: "Scale-to-zero is available for serving runtimes"
+- **TRUTH**: Scale-to-zero requires Knative Activator to buffer requests and wake pods. RHOAI uses RawDeployment (Standard) mode exclusively, which does **NOT** support scale-to-zero. Minimum replica count must be >= 1.
+- Source: KServe dependencies matrix; RawDeployment mode architecture; Knative KPA documentation.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Enriches overlay 0014 (Model Runtimes team architecture) with comprehensive context that prevents AI-generated strategy failures. Motivated by two concrete cases:

- **RHAISTRAT-1868** — AI proposed OVMS CUDA + package swap in CPU base; Staff Engineer review revealed `aipcc/cpu` lacks CUDA libs entirely
- **RHAISTRAT-2011** — AI proposed TrainedModel CRD + kserve-agent; Staff Engineer review found both are deprecated/incompatible with RHOAI

## Changes (334 lines added)

### New sections:
- **AIPCC Base Image Architecture** — `cpu`/`cuda` mutual exclusivity, hermetic build mandate, package onboarding lead time (1–3 weeks), runtime-specific status, anti-patterns table
- **Cross-Team Dependency Decision Matrix** — 10 Model Runtimes actions mapped against Dashboard, KServe/Platform, ODH Model Controller, and Release Engineering (most are "No dependency")
- **KServe Deprecation & Multi-Model Landscape** — community health, release cadence, TrainedModel (DO NOT USE), ModelMesh (ARCHIVED), kserve-agent (incompatible), LLMInferenceService (strategic future), InferenceGraph (alpha), RawDeployment limitations
- **Serving Runtime Template Catalog** — all 12 existing + planned templates with multi-model capability column
- **Impact on Strategies — 8 additional FALSE/TRUTH corrections**

### Correction:
- MLServer GPU support: changed from "package swap, no separate image needed" to "requires separate `aipcc/cuda` image" with explanation of `libcudart.so` crash scenario

## Relationship to existing overlays
- Complements **0017-aipcc-base-images** (Doug Hellmann) which covers AIPCC from Platform perspective; this adds Model Runtimes-specific consumption patterns and constraints
- Builds on **0011-kserve-llm-d-architecture** which covers LLM path; this adds classical serving + deprecation context

## Test plan
- [ ] Verify overlay passes `validate_architecture.py` (if applicable to overlays)
- [ ] Confirm `strat-creator` `fetch-architecture-context.sh` picks up the new content
- [ ] Run `/strategy-refine` against a multi-model STRAT to verify the new context prevents TrainedModel proposals


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture guidance for model runtimes, including clearer CPU vs. GPU image requirements and dependency timing expectations.
  * Added broader guidance for serving strategies, including supported multi-model paths, current limitations, and deprecated or incompatible approaches.
  * Expanded reference material on build, deployment, and cross-team decision-making rules for runtime images and strategy selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->