### PR TITLE
feat: add --strace flag to instrument agent calls with syscall tracing

### DIFF
--- a/lib/agent_runner.py
+++ b/lib/agent_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -248,8 +249,9 @@ async def run_agents_concurrently(
     def _strace_dir_for(job_name: str) -> Path | None:
         if strace_prefix is None:
             return None
-        safe_name = job_name.replace("/", "_")
-        return Path("logs/strace") / f"{strace_prefix}-{safe_name}"
+        safe_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", strace_prefix)
+        safe_name = re.sub(r"[^a-zA-Z0-9._-]", "_", job_name)
+        return Path("logs/strace") / f"{safe_prefix}-{safe_name}"
 
     # Single job: skip the progress panel — just run directly with heartbeat
     if total == 1:

--- a/lib/agent_runner.py
+++ b/lib/agent_runner.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 
+from lib.strace_transport import StracedTransport, empty_async_iter
+
 if TYPE_CHECKING:
     from lib.progress import AgentProgress
 
@@ -69,6 +71,7 @@ async def run_agent(
     name: str, cwd: str, prompt: str, log_dir: Path,
     model: str = "opus", enable_skills: bool = False,
     progress: AgentProgress | None = None,
+    strace_dir: Path | None = None,
 ) -> dict:
     """
     Launch one independent Claude agent session.
@@ -104,11 +107,22 @@ async def run_agent(
 
     _log = progress.log if progress else print
 
+    transport = None
+    if strace_dir is not None:
+        strace_dir.mkdir(parents=True, exist_ok=True)
+        transport = StracedTransport(
+            prompt=empty_async_iter(),
+            options=options,
+            strace_output_path=strace_dir / "trace",
+        )
+
     _log(f"\n{'=' * 60}")
     _log(f"Starting agent: {name}")
     _log(f"Model: {model}")
     _log(f"Working directory: {cwd}")
     _log(f"Log file: {log_file}")
+    if strace_dir is not None:
+        _log(f"Strace output: {strace_dir}")
     _log(f"{'=' * 60}")
 
     # Write log header before try block so error handler always has context
@@ -147,7 +161,7 @@ async def run_agent(
 
     try:
         with open(log_file, 'a') as log:
-            async with ClaudeSDKClient(options=options) as client:
+            async with ClaudeSDKClient(options=options, transport=transport) as client:
                 await client.query(prompt)
 
                 async for msg in client.receive_response():
@@ -211,6 +225,7 @@ async def run_agents_concurrently(
     model: str,
     max_concurrent: int,
     enable_skills: bool = False,
+    strace_prefix: str | None = None,
 ) -> list:
     """
     Run multiple agent jobs with a concurrency limit.
@@ -230,6 +245,12 @@ async def run_agents_concurrently(
     """
     total = len(jobs)
 
+    def _strace_dir_for(job_name: str) -> Path | None:
+        if strace_prefix is None:
+            return None
+        safe_name = job_name.replace("/", "_")
+        return Path("logs/strace") / f"{strace_prefix}-{safe_name}"
+
     # Single job: skip the progress panel — just run directly with heartbeat
     if total == 1:
         job = jobs[0]
@@ -237,6 +258,7 @@ async def run_agents_concurrently(
             result = await run_agent(
                 job["name"], job["cwd"], job["prompt"], log_dir, model,
                 enable_skills=enable_skills,
+                strace_dir=_strace_dir_for(job["name"]),
             )
         except BaseException as e:
             if isinstance(e, (KeyboardInterrupt, SystemExit)):
@@ -269,6 +291,7 @@ async def run_agents_concurrently(
                     job["name"], job["cwd"], job["prompt"], log_dir, model,
                     enable_skills=enable_skills,
                     progress=progress,
+                    strace_dir=_strace_dir_for(job["name"]),
                 )
         except BaseException as e:
             if isinstance(e, (KeyboardInterrupt, SystemExit)):

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -45,6 +45,16 @@ def resolve_script_path(
     return f"{checkouts_dir}/{org_dir}/{operator_name}/get_all_manifests.sh"
 
 
+def _add_strace_flag(parser):
+    """Add --strace flag to a subparser."""
+    parser.add_argument(
+        "--strace",
+        action="store_true",
+        default=False,
+        help="Run agents under strace (output to logs/strace/)",
+    )
+
+
 def parse_args():
     """Parse command line arguments with subcommands for each phase."""
     parser = argparse.ArgumentParser(
@@ -212,6 +222,7 @@ def parse_args():
             " many repos and needs large context)"
         ),
     )
+    _add_strace_flag(discover_parser)
 
     # Phase 2c: Static analysis (arch-analyzer)
     static_analysis_parser = subparsers.add_parser(
@@ -326,6 +337,7 @@ def parse_args():
             " tiers only)"
         ),
     )
+    _add_strace_flag(generate_arch_parser)
 
     # Phase 4b: Webhook inventory
     webhook_parser = subparsers.add_parser(
@@ -367,6 +379,7 @@ def parse_args():
         default=5,
         help="Maximum concurrent analysis agents (default: 5)"
     )
+    _add_strace_flag(webhook_parser)
 
     # Phase 4: Collect architectures
     collect_parser = subparsers.add_parser(
@@ -441,6 +454,7 @@ def parse_args():
             " large context)"
         ),
     )
+    _add_strace_flag(platform_arch_parser)
 
     # Phase 6: Generate diagrams
     diagrams_parser = subparsers.add_parser(
@@ -496,6 +510,7 @@ def parse_args():
         default="opus",
         help="Claude model to use (default: opus)"
     )
+    _add_strace_flag(diagrams_parser)
 
     # All phases
     all_parser = subparsers.add_parser(
@@ -590,5 +605,6 @@ def parse_args():
         default=False,
         help="Export Mermaid diagrams to PNG (requires mmdc + Chrome; off by default)"
     )
+    _add_strace_flag(all_parser)
 
     return parser.parse_args()

--- a/lib/phases/architecture.py
+++ b/lib/phases/architecture.py
@@ -160,8 +160,13 @@ async def run_generate_architecture_phase(args) -> None:
     print(f"Model: {args.model}")
     print(f"{'=' * 60}\n")
 
+    strace_prefix = (
+        f"{args.platform}-generate-architecture"
+        if getattr(args, 'strace', False) else None
+    )
     results = await run_agents_concurrently(
         jobs, log_dir, args.model, args.max_concurrent, enable_skills=True,
+        strace_prefix=strace_prefix,
     )
 
     # Recover crashed agents that still produced output.

--- a/lib/phases/diagrams.py
+++ b/lib/phases/diagrams.py
@@ -220,6 +220,11 @@ async def run_generate_diagrams_phase(args) -> None:
     print(f"Model: {args.model}")
     print(f"{'=' * 60}\n")
 
+    strace_prefix = (
+        f"{args.platform}-generate-diagrams"
+        if getattr(args, 'strace', False) else None
+    )
+
     # Run platform diagrams first, then component diagrams
     all_results = []
     all_jobs = []
@@ -227,7 +232,8 @@ async def run_generate_diagrams_phase(args) -> None:
     if platform_jobs:
         print("--- Phase 6a: Platform diagrams ---\n")
         platform_results = await run_agents_concurrently(
-            platform_jobs, log_dir, args.model, args.max_concurrent, enable_skills=True,
+            platform_jobs, log_dir, args.model, args.max_concurrent,
+            enable_skills=True, strace_prefix=strace_prefix,
         )
         all_results.extend(platform_results)
         all_jobs.extend(platform_jobs)
@@ -237,6 +243,7 @@ async def run_generate_diagrams_phase(args) -> None:
         component_results = await run_agents_concurrently(
             component_jobs, log_dir, args.model,
             args.max_concurrent, enable_skills=True,
+            strace_prefix=strace_prefix,
         )
         all_results.extend(component_results)
         all_jobs.extend(component_jobs)

--- a/lib/phases/discover.py
+++ b/lib/phases/discover.py
@@ -175,6 +175,13 @@ async def run_discover_components_phase(args) -> None:
     print(f"Model: {model}")
     print(f"Log directory: {log_dir}\n")
 
+    strace_dir = None
+    if getattr(args, 'strace', False):
+        strace_dir = (
+            Path("logs/strace")
+            / f"{args.platform}-discover-components-discover-{args.platform}"
+        )
+
     result = await run_agent(
         name=f"discover-{args.platform}",
         cwd=".",
@@ -182,6 +189,7 @@ async def run_discover_components_phase(args) -> None:
         log_dir=log_dir,
         model=model,
         enable_skills=True,
+        strace_dir=strace_dir,
     )
 
     print("\n" + "=" * 60)

--- a/lib/phases/discover.py
+++ b/lib/phases/discover.py
@@ -1,6 +1,7 @@
 """Phase 2b: Discover components via breadcrumb exploration."""
 
 import json
+import re
 from pathlib import Path
 
 from lib.agent_runner import run_agent
@@ -177,9 +178,10 @@ async def run_discover_components_phase(args) -> None:
 
     strace_dir = None
     if getattr(args, 'strace', False):
+        safe_platform = re.sub(r"[^a-zA-Z0-9._-]", "_", args.platform)
         strace_dir = (
             Path("logs/strace")
-            / f"{args.platform}-discover-components-discover-{args.platform}"
+            / f"{safe_platform}-discover-components-discover-{safe_platform}"
         )
 
     result = await run_agent(

--- a/lib/phases/orchestration.py
+++ b/lib/phases/orchestration.py
@@ -180,6 +180,8 @@ async def run_all_phases(args) -> None:
     )
     await run_manifest_phase(manifest_args)
 
+    strace = getattr(args, 'strace', False)
+
     # Phase 2b: Discover components
     discover_args = Namespace(
         platform=args.platform,
@@ -189,6 +191,7 @@ async def run_all_phases(args) -> None:
         exclude=None,
         model=getattr(args, 'model', 'opus'),
         force=force,
+        strace=strace,
     )
     await run_discover_components_phase(discover_args)
 
@@ -214,6 +217,7 @@ async def run_all_phases(args) -> None:
         force=force,
         model=getattr(args, 'model', 'opus'),
         tier=getattr(args, 'tier', 'all'),
+        strace=strace,
     )
     await run_generate_architecture_phase(generate_arch_args)
 
@@ -276,6 +280,7 @@ async def run_all_phases(args) -> None:
         force=force,
         model=getattr(args, 'model', 'sonnet'),
         max_concurrent=getattr(args, 'max_concurrent', 5),
+        strace=strace,
     )
     await run_webhook_inventory_phase(webhook_args)
 
@@ -288,7 +293,8 @@ async def run_all_phases(args) -> None:
         max_concurrent=max_concurrent,
         limit=None,
         force=force,
-        model=getattr(args, 'model', 'opus')
+        model=getattr(args, 'model', 'opus'),
+        strace=strace,
     )
     await run_generate_platform_architecture_phase(platform_arch_args)
 
@@ -306,6 +312,7 @@ async def run_all_phases(args) -> None:
             force_regenerate=force,
             export_png=getattr(args, 'export_png', False),
             model=getattr(args, 'model', 'opus'),
+            strace=strace,
         )
         await run_generate_diagrams_phase(diagrams_args)
 

--- a/lib/phases/platform.py
+++ b/lib/phases/platform.py
@@ -198,8 +198,13 @@ async def run_generate_platform_architecture_phase(args) -> None:
     print(f"Model: {args.model}")
     print(f"{'=' * 60}\n")
 
+    strace_prefix = (
+        f"{args.platform}-generate-platform-architecture"
+        if getattr(args, 'strace', False) else None
+    )
     results = await run_agents_concurrently(
         jobs, log_dir, args.model, args.max_concurrent, enable_skills=True,
+        strace_prefix=strace_prefix,
     )
 
     # Summary

--- a/lib/phases/webhooks.py
+++ b/lib/phases/webhooks.py
@@ -238,9 +238,14 @@ async def run_webhook_inventory_phase(args) -> None:
     model = getattr(args, 'model', 'sonnet')
     max_concurrent = getattr(args, 'max_concurrent', 5)
     if component_repos:
+        wh_strace_prefix = (
+            f"{args.platform}-webhook-inventory"
+            if getattr(args, 'strace', False) else None
+        )
         await run_webhook_agent_analysis(
             webhooks, component_repos,
             model=model, max_concurrent=max_concurrent,
+            strace_prefix=wh_strace_prefix,
         )
         with_purpose = sum(1 for wh in webhooks if wh.purpose)
         print(f"Webhooks with purpose: {with_purpose}/{len(webhooks)}")

--- a/lib/strace_transport.py
+++ b/lib/strace_transport.py
@@ -1,0 +1,30 @@
+"""Strace-instrumented transport for Claude Agent SDK."""
+
+from claude_agent_sdk._internal.transport.subprocess_cli import SubprocessCLITransport
+
+
+class StracedTransport(SubprocessCLITransport):
+    """Wraps the Claude CLI command with strace for syscall tracing."""
+
+    def __init__(self, *args, strace_output_path=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._strace_output_path = strace_output_path
+
+    def _build_command(self):
+        cmd = super()._build_command()
+        if self._strace_output_path is None:
+            return cmd
+        return [
+            "strace",
+            "-ffttv",
+            "-s", "1024",
+            "-e", "trace=file,network",
+            "-o", str(self._strace_output_path),
+            "--",
+        ] + cmd
+
+
+async def empty_async_iter():
+    """Dummy async iterable — SubprocessCLITransport stores but never reads it."""
+    return
+    yield

--- a/lib/webhook_analyzer.py
+++ b/lib/webhook_analyzer.py
@@ -1152,6 +1152,7 @@ async def run_webhook_agent_analysis(
     component_repos: dict[str, Path],
     model: str = "sonnet",
     max_concurrent: int = 5,
+    strace_prefix: str | None = None,
 ) -> None:
     """Spawn Claude agents to analyze Go webhook handler code.
 
@@ -1230,6 +1231,7 @@ async def run_webhook_agent_analysis(
     print(f"  Analyzing {len(jobs)} unique handler files with {model} agents")
     results = await run_agents_concurrently(
         jobs, log_dir, model, max_concurrent,
+        strace_prefix=strace_prefix,
     )
 
     analyzed = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,12 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff>=0.11",
+    "pytest>=9.0",
+    "pytest-asyncio>=1.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
 
 [tool.ruff]
 target-version = "py313"

--- a/tests/test_strace_agent.py
+++ b/tests/test_strace_agent.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Proof-of-concept: run a Claude agent under strace via transport subclass."""
+
+import asyncio
+import shutil
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    ResultMessage,
+    TextBlock,
+)
+
+from lib.strace_transport import StracedTransport, empty_async_iter
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+PLATFORM = "test"
+SKILL = "strace-validation"
+COMPONENT = "hello-agent"
+
+
+async def run_test():
+    strace_dir = PROJECT_ROOT / "logs" / "strace" / f"{PLATFORM}-{SKILL}-{COMPONENT}"
+
+    if strace_dir.exists():
+        shutil.rmtree(strace_dir)
+    strace_dir.mkdir(parents=True)
+
+    strace_base = strace_dir / "trace"
+    print(f"strace output: {strace_dir.relative_to(PROJECT_ROOT)}/")
+
+    options = ClaudeAgentOptions(
+        model="claude-sonnet-4-5",
+        permission_mode="bypassPermissions",
+        allowed_tools=[],
+        system_prompt="",
+    )
+
+    transport = StracedTransport(
+        prompt=empty_async_iter(),
+        options=options,
+        strace_output_path=strace_base,
+    )
+
+    result_text = None
+    got_result = False
+
+    async with ClaudeSDKClient(options=options, transport=transport) as client:
+        await client.query("Reply with the single word: hello")
+        async for msg in client.receive_response():
+            if isinstance(msg, ResultMessage):
+                got_result = True
+            elif hasattr(msg, "content"):
+                for block in msg.content:
+                    if isinstance(block, TextBlock):
+                        result_text = block.text
+
+    # --- Verify agent response ---
+    print(f"\nagent response: {result_text}")
+    assert got_result, "never received ResultMessage"
+
+    # --- Verify strace files ---
+    strace_files = sorted(strace_dir.glob("trace.*"))
+    total_bytes = sum(f.stat().st_size for f in strace_files)
+    print(f"strace files:    {len(strace_files)}")
+    print(f"total bytes:     {total_bytes}")
+
+    assert len(strace_files) > 0, "no strace output files found"
+    assert total_bytes > 0, "strace files are empty"
+
+    # --- Sample syscalls from largest file ---
+    largest = max(strace_files, key=lambda f: f.stat().st_size)
+    syscall_names = set()
+    with open(largest) as f:
+        for line in f:
+            parts = line.split("(", 1)
+            if len(parts) == 2:
+                token = parts[0].rsplit(None, 1)
+                if token:
+                    syscall_names.add(token[-1])
+
+    print(f"syscalls found:  {sorted(syscall_names)}")
+    assert syscall_names, "could not parse any syscall names from strace output"
+
+    print("\nPASS")
+
+
+def main():
+    env_path = PROJECT_ROOT / ".env"
+    if env_path.exists():
+        load_dotenv(dotenv_path=env_path)
+    else:
+        print(f"warning: {env_path} not found, relying on ambient env", file=sys.stderr)
+
+    asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_strace_agent.py
+++ b/tests/test_strace_agent.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Proof-of-concept: run a Claude agent under strace via transport subclass."""
 
+import asyncio
 import os
 import shutil
 import sys
@@ -69,17 +70,21 @@ async def test_strace_agent():
     result_text = None
     got_result = False
 
-    async with ClaudeSDKClient(
-        options=options, transport=transport,
-    ) as client:
-        await client.query("Reply with the single word: hello")
-        async for msg in client.receive_response():
-            if isinstance(msg, ResultMessage):
-                got_result = True
-            elif hasattr(msg, "content"):
-                for block in msg.content:
-                    if isinstance(block, TextBlock):
-                        result_text = block.text
+    async def _run_agent():
+        nonlocal result_text, got_result
+        async with ClaudeSDKClient(
+            options=options, transport=transport,
+        ) as client:
+            await client.query("Reply with the single word: hello")
+            async for msg in client.receive_response():
+                if isinstance(msg, ResultMessage):
+                    got_result = True
+                elif hasattr(msg, "content"):
+                    for block in msg.content:
+                        if isinstance(block, TextBlock):
+                            result_text = block.text
+
+    await asyncio.wait_for(_run_agent(), timeout=120)
 
     assert got_result, "never received ResultMessage"
     assert result_text is not None, "no text in agent response"

--- a/tests/test_strace_agent.py
+++ b/tests/test_strace_agent.py
@@ -1,45 +1,57 @@
 #!/usr/bin/env python3
 """Proof-of-concept: run a Claude agent under strace via transport subclass."""
 
-import asyncio
+import os
 import shutil
 import sys
 from pathlib import Path
 
+import pytest
 from dotenv import load_dotenv
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from claude_agent_sdk import (
-    ClaudeAgentOptions,
-    ClaudeSDKClient,
-    ResultMessage,
-    TextBlock,
-)
-
-from lib.strace_transport import StracedTransport, empty_async_iter
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+# Load .env before any SDK imports so credentials are available
+_env_path = PROJECT_ROOT / ".env"
+if _env_path.exists():
+    load_dotenv(dotenv_path=_env_path)
 
-# ---------------------------------------------------------------------------
-# Test
-# ---------------------------------------------------------------------------
+sys.path.insert(0, str(PROJECT_ROOT))
+
+_has_api_creds = bool(
+    os.environ.get("ANTHROPIC_API_KEY")
+    or os.environ.get("CLAUDE_CODE_USE_VERTEX")
+)
+_has_strace = shutil.which("strace") is not None
 
 PLATFORM = "test"
 SKILL = "strace-validation"
 COMPONENT = "hello-agent"
 
 
-async def run_test():
-    strace_dir = PROJECT_ROOT / "logs" / "strace" / f"{PLATFORM}-{SKILL}-{COMPONENT}"
+@pytest.mark.skipif(not _has_api_creds, reason="no API credentials")
+@pytest.mark.skipif(not _has_strace, reason="strace not installed")
+@pytest.mark.asyncio
+async def test_strace_agent():
+    from claude_agent_sdk import (
+        ClaudeAgentOptions,
+        ClaudeSDKClient,
+        ResultMessage,
+        TextBlock,
+    )
+
+    from lib.strace_transport import StracedTransport, empty_async_iter
+
+    strace_dir = (
+        PROJECT_ROOT / "logs" / "strace"
+        / f"{PLATFORM}-{SKILL}-{COMPONENT}"
+    )
 
     if strace_dir.exists():
         shutil.rmtree(strace_dir)
     strace_dir.mkdir(parents=True)
 
     strace_base = strace_dir / "trace"
-    print(f"strace output: {strace_dir.relative_to(PROJECT_ROOT)}/")
 
     options = ClaudeAgentOptions(
         model="claude-sonnet-4-5",
@@ -57,7 +69,9 @@ async def run_test():
     result_text = None
     got_result = False
 
-    async with ClaudeSDKClient(options=options, transport=transport) as client:
+    async with ClaudeSDKClient(
+        options=options, transport=transport,
+    ) as client:
         await client.query("Reply with the single word: hello")
         async for msg in client.receive_response():
             if isinstance(msg, ResultMessage):
@@ -67,20 +81,15 @@ async def run_test():
                     if isinstance(block, TextBlock):
                         result_text = block.text
 
-    # --- Verify agent response ---
-    print(f"\nagent response: {result_text}")
     assert got_result, "never received ResultMessage"
+    assert result_text is not None, "no text in agent response"
 
-    # --- Verify strace files ---
     strace_files = sorted(strace_dir.glob("trace.*"))
     total_bytes = sum(f.stat().st_size for f in strace_files)
-    print(f"strace files:    {len(strace_files)}")
-    print(f"total bytes:     {total_bytes}")
 
     assert len(strace_files) > 0, "no strace output files found"
     assert total_bytes > 0, "strace files are empty"
 
-    # --- Sample syscalls from largest file ---
     largest = max(strace_files, key=lambda f: f.stat().st_size)
     syscall_names = set()
     with open(largest) as f:
@@ -91,21 +100,6 @@ async def run_test():
                 if token:
                     syscall_names.add(token[-1])
 
-    print(f"syscalls found:  {sorted(syscall_names)}")
-    assert syscall_names, "could not parse any syscall names from strace output"
-
-    print("\nPASS")
-
-
-def main():
-    env_path = PROJECT_ROOT / ".env"
-    if env_path.exists():
-        load_dotenv(dotenv_path=env_path)
-    else:
-        print(f"warning: {env_path} not found, relying on ambient env", file=sys.stderr)
-
-    asyncio.run(run_test())
-
-
-if __name__ == "__main__":
-    main()
+    assert syscall_names, (
+        "could not parse any syscall names from strace output"
+    )


### PR DESCRIPTION
Subclasses the SDK's SubprocessCLITransport to prepend strace to the claude CLI command, capturing file I/O, network, and process activity per agent invocation. Output lands in logs/strace/<platform>-<skill>-<component>/.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional syscall tracing for agent runs via a new `--strace` CLI flag, writing output under `logs/strace/`.
  * Tracing is now supported across discovery, architecture generation, platform/diagram generation, webhook inventory, and the overall “all” workflow.
* **Improvements**
  * Concurrent runs propagate tracing settings and generate per-job trace directories (sanitized from platform/job names).
* **Tests**
  * Added an async integration test that verifies trace artifacts exist, are non-empty, and contain parsed syscall-like entries.
* **Chores**
  * Updated dev test dependencies and tightened pytest async configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->