### PR TITLE
feat: add image dependency discovery to discover-components skill

### DIFF
--- a/.claude/skills/discover-components/SKILL.md
+++ b/.claude/skills/discover-components/SKILL.md
@@ -225,6 +225,20 @@ For each matched repo, if not already in the component list, add as `discovered_
 
 **Binding rule:** Any repo matched by `parse_catalog_images.py` MUST be included as a component. Do NOT override these matches by reclassifying the repo as excluded. The OLM catalog's `relatedImages` is the authoritative list of container images shipped in the product — if a repo's image is in the catalog, the repo is a shipped component regardless of whether it looks like "infrastructure," a "utility," or "covered by" another component. The only exception is build infrastructure repos like `RHOAI-Build-Config` itself.
 
+**5.1c: Discover components shipped as Python dependencies in container images.** Some components ship as pip packages baked into container images (e.g. notebook workbenches) rather than as standalone Kubernetes workloads. These have no DSC field, no RELATED_IMAGE mapping, and no OLM catalog entry — but they are shipped components.
+
+For each `core_platform` or `optional_platform` component that builds container images with Python dependencies (primarily `notebooks`), run the helper script:
+
+```bash
+python ${CLAUDE_SKILL_DIR}/scripts/parse_image_dependencies.py {image_repo_checkout} {checkouts_dir1} {checkouts_dir2} ...
+```
+
+The script scans `pyproject.toml` and `requirements*.txt` files in the image repo, extracts Python package names, and matches them against repos in the checkouts directories. Output is JSON with `repos` (matched) and `unmatched` sections.
+
+For each matched repo in the output, if not already in the component list, add as `discovered_via: "image_dependency"`, `referenced_by: ["{image-repo-name}"]`. Use the tier already assigned in Step 2a if the repo was classified there; otherwise default to `tier: "payload_component"`.
+
+**Binding rule:** Any repo matched by `parse_image_dependencies.py` MUST be included as a component. A repo whose package is pip-installed into a shipped container image is a shipped component — it runs inside the product regardless of whether it has its own Kubernetes workload.
+
 **5.2: Scan `go.mod` for shared libraries.** Scan `go.mod` (or equivalent) of each discovered `core_platform` and `optional_platform` component. Look for first-party dependencies (same GitHub org) that match repos in the checkouts directory. This is how shared libraries like `library-go`, `api`, `client-go` get discovered.
 
 As you discover references:

--- a/.claude/skills/discover-components/SKILL.md
+++ b/.claude/skills/discover-components/SKILL.md
@@ -52,7 +52,7 @@ Exclude obvious non-components:
   - `must-gather`, `additional-images`
   - Build/release infrastructure repos (`RHOAI-Build-Config`, `konflux-central`)
 
-**Do NOT exclude** `odh-cli` — it is a shipped component starting with RHOAI 3.3+.
+**Do NOT exclude** `odh-cli` -- it is a shipped component starting with RHOAI 3.3+.
 
 Create an initial list of candidate repos.
 
@@ -81,12 +81,12 @@ Each directory name maps to a DSC field. Cross-reference with the RELATED_IMAGE 
 | Tier | Criteria | Examples |
 |------|----------|---------|
 | `core_platform` | The meta-operator itself AND components that are always deployed (not togglable via DSC) | `rhods-operator`, `opendatahub-operator`, `odh-dashboard`, `notebooks`, `odh-model-controller` |
-| `optional_platform` | Components with a DSC field — user can set `managementState: Managed/Removed` | `kserve`, `data-science-pipelines-operator`, `codeflare-operator`, `kuberay`, `kueue`, `trustyai-service-operator`, `model-registry-operator`, `modelmesh-serving`, `trainer`, `training-operator`, `spark-operator`, `feast`, `llama-stack-k8s-operator`, `mlflow-operator`, `models-as-a-service`, `workload-variant-autoscaler` |
-| `payload_component` | Shipped containers/libraries deployed BY core or optional components — not independently togglable | `vllm`, `data-science-pipelines`, `model-registry`, `codeflare-sdk`, `modelmesh`, `rest-proxy` |
+| `optional_platform` | Components with a DSC field -- user can set `managementState: Managed/Removed` | `kserve`, `data-science-pipelines-operator`, `codeflare-operator`, `kuberay`, `kueue`, `trustyai-service-operator`, `model-registry-operator`, `modelmesh-serving`, `trainer`, `training-operator`, `spark-operator`, `feast`, `llama-stack-k8s-operator`, `mlflow-operator`, `models-as-a-service`, `workload-variant-autoscaler` |
+| `payload_component` | Shipped containers/libraries deployed BY core or optional components -- not independently togglable | `vllm`, `data-science-pipelines`, `model-registry`, `codeflare-sdk`, `modelmesh`, `rest-proxy` |
 
-**Key distinction:** `optional_platform` components are the ones a cluster admin toggles on/off. `payload_component` repos provide the container images or libraries that optional_platform operators deploy — they don't have their own DSC toggle.
+**Key distinction:** `optional_platform` components are the ones a cluster admin toggles on/off. `payload_component` repos provide the container images or libraries that optional_platform operators deploy -- they don't have their own DSC toggle.
 
-**Dashboard, notebooks, and odh-model-controller** are `core_platform` even though they appear as DSC fields — they are always-on components required for the platform to function. The DSC fields for these exist for configuration, not for enable/disable.
+**Dashboard, notebooks, and odh-model-controller** are `core_platform` even though they appear as DSC fields -- they are always-on components required for the platform to function. The DSC fields for these exist for configuration, not for enable/disable.
 
 Set `discovery_method: "breadcrumb"` in metadata.
 
@@ -196,9 +196,9 @@ The script scans `internal/controller/components/*/*_support.go` for `imageParam
 
 For each matched repo in the output, if not already in the component list, add as `discovered_via: "operator_operand"`, `referenced_by: ["{operator-name}"]`. Use the tier already assigned in Step 2a if the repo was classified there; otherwise default to `tier: "payload_component"`.
 
-**Binding rule:** Any repo matched by `parse_related_images.py` MUST be included as a component. Do NOT override these matches by reclassifying the repo as excluded. The script identifies operands that the operator ships — if the operator references a container image built from a repo, that repo is a shipped component regardless of whether it looks like "infrastructure" or a "utility." The only exception is build infrastructure repos like `RHOAI-Build-Config` itself.
+**Binding rule:** Any repo matched by `parse_related_images.py` MUST be included as a component. Do NOT override these matches by reclassifying the repo as excluded. The script identifies operands that the operator ships -- if the operator references a container image built from a repo, that repo is a shipped component regardless of whether it looks like "infrastructure" or a "utility." The only exception is build infrastructure repos like `RHOAI-Build-Config` itself.
 
-**5.1b: Discover operands via OLM catalog relatedImages (RHOAI).** RHOAI has a build config repo (`RHOAI-Build-Config`) containing OLM catalog YAML with `relatedImages` sections — the authoritative list of every container image shipped in each version.
+**5.1b: Discover operands via OLM catalog relatedImages (RHOAI).** RHOAI has a build config repo (`RHOAI-Build-Config`) containing OLM catalog YAML with `relatedImages` sections -- the authoritative list of every container image shipped in each version.
 
 Run the helper script to parse the catalog and match images to repos:
 
@@ -214,18 +214,18 @@ python ${CLAUDE_SKILL_DIR}/scripts/parse_catalog_images.py --find-catalog --vers
 
 The script auto-finds the best `RHOAI-Build-Config/catalog/` directory, extracts unique images from `relatedImages` sections, and matches them to repos using multi-step normalization (strip `odh-` prefix, `-rhel[0-9]` suffix, hardware variant suffixes) plus known name mappings (e.g., `ml-pipelines-*` → `data-science-pipelines`, `dashboard` → `odh-dashboard`).
 
-The catalog directories are versioned by RHOAI release, not by checkout branch — `RHOAI-Build-Config` is typically checked out at `head` but contains catalogs for all historical versions. If no catalog directory exactly matches the target platform version, the script uses the **latest available version** as the best approximation.
+The catalog directories are versioned by RHOAI release, not by checkout branch -- `RHOAI-Build-Config` is typically checked out at `head` but contains catalogs for all historical versions. If no catalog directory exactly matches the target platform version, the script uses the **latest available version** as the best approximation.
 
 Output is JSON with:
 - `repos`: matched repos with image names and match method
 - `unmatched`: images with no repo match (third-party base images, internal tools)
 - `variant_groups`: images that are build variants of the same component
 
-For each matched repo, if not already in the component list, add as `discovered_via: "container_image"`, `referenced_by: ["rhods-operator"]`. Use the tier already assigned in Step 2a if the repo was classified there; otherwise default to `tier: "payload_component"`. Do NOT add `RHOAI-Build-Config` itself as a component — it is build infrastructure, not a shipped component. Unmatched images that are clearly third-party (`ubi-*`, `ose-*`, `postgresql-*`, `etcd`) should be ignored. Other unmatched images may represent components without source repos in the checkouts — note them but don't block on them.
+For each matched repo, if not already in the component list, add as `discovered_via: "container_image"`, `referenced_by: ["rhods-operator"]`. Use the tier already assigned in Step 2a if the repo was classified there; otherwise default to `tier: "payload_component"`. Do NOT add `RHOAI-Build-Config` itself as a component -- it is build infrastructure, not a shipped component. Unmatched images that are clearly third-party (`ubi-*`, `ose-*`, `postgresql-*`, `etcd`) should be ignored. Other unmatched images may represent components without source repos in the checkouts -- note them but don't block on them.
 
-**Binding rule:** Any repo matched by `parse_catalog_images.py` MUST be included as a component. Do NOT override these matches by reclassifying the repo as excluded. The OLM catalog's `relatedImages` is the authoritative list of container images shipped in the product — if a repo's image is in the catalog, the repo is a shipped component regardless of whether it looks like "infrastructure," a "utility," or "covered by" another component. The only exception is build infrastructure repos like `RHOAI-Build-Config` itself.
+**Binding rule:** Any repo matched by `parse_catalog_images.py` MUST be included as a component. Do NOT override these matches by reclassifying the repo as excluded. The OLM catalog's `relatedImages` is the authoritative list of container images shipped in the product -- if a repo's image is in the catalog, the repo is a shipped component regardless of whether it looks like "infrastructure," a "utility," or "covered by" another component. The only exception is build infrastructure repos like `RHOAI-Build-Config` itself.
 
-**5.1c: Discover components shipped as Python dependencies in container images.** Some components ship as pip packages baked into container images (e.g. notebook workbenches) rather than as standalone Kubernetes workloads. These have no DSC field, no RELATED_IMAGE mapping, and no OLM catalog entry — but they are shipped components.
+**5.1c: Discover components shipped as Python dependencies in container images.** Some components ship as pip packages baked into container images (e.g. notebook workbenches) rather than as standalone Kubernetes workloads. These have no DSC field, no RELATED_IMAGE mapping, and no OLM catalog entry -- but they are shipped components.
 
 For each `core_platform` or `optional_platform` component that builds container images with Python dependencies (primarily `notebooks`), run the helper script:
 
@@ -237,7 +237,7 @@ The script scans `pyproject.toml` and `requirements*.txt` files in the image rep
 
 For each matched repo in the output, if not already in the component list, add as `discovered_via: "image_dependency"`, `referenced_by: ["{image-repo-name}"]`. Use the tier already assigned in Step 2a if the repo was classified there; otherwise default to `tier: "payload_component"`.
 
-**Binding rule:** Any repo matched by `parse_image_dependencies.py` MUST be included as a component. A repo whose package is pip-installed into a shipped container image is a shipped component — it runs inside the product regardless of whether it has its own Kubernetes workload.
+**Binding rule:** Any repo matched by `parse_image_dependencies.py` MUST be included as a component. A repo whose package is pip-installed into a shipped container image is a shipped component -- it runs inside the product regardless of whether it has its own Kubernetes workload.
 
 **5.2: Scan `go.mod` for shared libraries.** Scan `go.mod` (or equivalent) of each discovered `core_platform` and `optional_platform` component. Look for first-party dependencies (same GitHub org) that match repos in the checkouts directory. This is how shared libraries like `library-go`, `api`, `client-go` get discovered.
 
@@ -246,7 +246,7 @@ As you discover references:
 2. If yes, add to component list with `discovered_via` and `referenced_by`
 3. Track what type of reference (deployed_component vs. dependency vs. operand)
 4. Mark as `shipped: true` if deployed directly
-5. **Always populate the `dependency_graph`** — even in signal mode, record which components depend on which
+5. **Always populate the `dependency_graph`** -- even in signal mode, record which components depend on which
 
 Track the dependency graph:
 ```
@@ -279,7 +279,7 @@ Repos not discovered via DSC spec, RELATED_IMAGE mappings, OLM catalog, or depen
 
 ### Step 6a: Multi-Reviewer Consensus for Low-Confidence Repos
 
-See [consensus review procedure](references/consensus-review.md) for the full multi-reviewer consensus process — when to trigger it, the 3 reviewer prompts (structural, relational, functional), vote aggregation rules, and how to record consensus results in the component map.
+See [consensus review procedure](references/consensus-review.md) for the full multi-reviewer consensus process -- when to trigger it, the 3 reviewer prompts (structural, relational, functional), vote aggregation rules, and how to record consensus results in the component map.
 
 ### Step 7: Check for Existing Architectures
 
@@ -304,7 +304,7 @@ See [output schema](references/output-schema.md) for the full component-map.json
 
 Write to `architecture/{platform}/component-map.json`.
 
-**Always overwrite** the existing file if one is present — the user is re-running discovery to get updated results. Do NOT skip writing because the file already exists.
+**Always overwrite** the existing file if one is present -- the user is re-running discovery to get updated results. Do NOT skip writing because the file already exists.
 
 ### Step 9a: Validate Output
 

--- a/.claude/skills/discover-components/references/output-schema.md
+++ b/.claude/skills/discover-components/references/output-schema.md
@@ -29,7 +29,7 @@ Create the component map structure:
       "has_architecture": false,
       "type": "operator|controller|service|ui|installer|asset|shared_library|api_specification",
       "tier": "core_platform|optional_platform|payload_component|ecosystem",
-      "discovered_via": "operator_operand|operator_bundle|container_image|dependency|installer|dsc_spec",
+      "discovered_via": "operator_operand|operator_bundle|container_image|image_dependency|dependency|installer|dsc_spec",
       "referenced_by": ["installer"],
       "shipped": true,
       "architecturally_significant": true,

--- a/.claude/skills/discover-components/scripts/parse_image_dependencies.py
+++ b/.claude/skills/discover-components/scripts/parse_image_dependencies.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Parse Python dependencies from container image build repos.
+
+Usage:
+    python parse_image_dependencies.py <image_repo> <checkouts_dir> ...
+
+Scans pyproject.toml and requirements*.txt files in an image-building repo
+(e.g. notebooks), extracts Python package names, and matches them against
+repos in the checkouts directories.
+
+Output: JSON with matched repos, unmatched packages, and metadata.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+KNOWN_MAPPINGS = {
+    "codeflare-sdk": "codeflare-sdk",
+    "kfp": "data-science-pipelines",
+    "kfp-server-api": "data-science-pipelines",
+    "mlflow": "mlflow",
+    "ray": "kuberay",
+}
+
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".tox", ".venv"}
+
+VERSION_RE = re.compile(r"[><=!~]")
+EXTRAS_RE = re.compile(r"\[.*?\]")
+
+
+def find_repo(name, repo_sets):
+    """Try to match a package name to a repo."""
+    if name in KNOWN_MAPPINGS:
+        mapped = KNOWN_MAPPINGS[name]
+        for repos in repo_sets:
+            if mapped in repos:
+                return mapped, "known_mapping"
+
+    for repos in repo_sets:
+        if name in repos:
+            return name, "direct"
+
+    parts = name.split("-")
+    for length in range(len(parts) - 1, 0, -1):
+        candidate = "-".join(parts[:length])
+        for repos in repo_sets:
+            if candidate in repos:
+                return candidate, "parent_repo"
+
+    return None, None
+
+
+def normalize_package_name(raw):
+    """Normalize a Python package name to its canonical form."""
+    name = raw.strip().lower()
+    name = EXTRAS_RE.sub("", name)
+    name = name.replace("_", "-")
+    return name
+
+
+def extract_package_name(line):
+    """Extract the package name from a dependency line.
+
+    Handles formats like:
+        package-name
+        package-name>=1.0
+        package-name==1.2.3
+        package-name[extra1,extra2]>=1.0
+        package-name; platform_machine != 's390x'
+        package-name==1.0 ; env_marker \\ --hash=sha256:...
+    """
+    line = line.strip()
+    if not line or line.startswith("#") or line.startswith("-"):
+        return None
+
+    semi_pos = line.find(";")
+    if semi_pos > 0:
+        line = line[:semi_pos]
+
+    match = VERSION_RE.search(line)
+    if match:
+        line = line[:match.start()]
+
+    line = line.strip()
+    if not line:
+        return None
+
+    return normalize_package_name(line)
+
+
+def parse_requirements_txt(filepath):
+    """Extract package names from a requirements.txt file."""
+    packages = set()
+    try:
+        for line in filepath.read_text().splitlines():
+            line = line.split("\\")[0].strip()
+            name = extract_package_name(line)
+            if name:
+                packages.add(name)
+    except (OSError, UnicodeDecodeError):
+        pass
+    return packages
+
+
+def parse_pyproject_toml(filepath):
+    """Extract package names from a pyproject.toml dependencies list."""
+    packages = set()
+    try:
+        content = filepath.read_text()
+    except (OSError, UnicodeDecodeError):
+        return packages
+
+    in_deps = False
+    for line in content.splitlines():
+        stripped = line.strip()
+
+        if stripped in (
+            "dependencies = [",
+            "override-dependencies = [",
+        ):
+            in_deps = True
+            continue
+
+        if in_deps:
+            if stripped == "]":
+                in_deps = False
+                continue
+
+            match = re.search(r'"([^"]+)"', stripped)
+            if match:
+                name = extract_package_name(match.group(1))
+                if name:
+                    packages.add(name)
+
+    return packages
+
+
+def find_dependency_files(repo_path):
+    """Find all pyproject.toml and requirements*.txt in the repo."""
+    pyprojects = []
+    requirements = []
+
+    for path in repo_path.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.name == "pyproject.toml":
+            pyprojects.append(path)
+        elif path.name.startswith("requirements") and path.suffix == ".txt":
+            requirements.append(path)
+
+    return sorted(pyprojects), sorted(requirements)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(
+            f"Usage: {sys.argv[0]} <image_repo> <checkouts_dir>"
+            f" [<checkouts_dir2> ...]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    image_repo = Path(sys.argv[1])
+    checkouts_dirs = sys.argv[2:]
+
+    if not image_repo.is_dir():
+        print(json.dumps({"error": f"Not a directory: {image_repo}"}))
+        sys.exit(1)
+
+    repo_sets = []
+    for cdir in checkouts_dirs:
+        cdir_path = Path(cdir)
+        if cdir_path.exists():
+            repos = {
+                d.name
+                for d in cdir_path.iterdir()
+                if d.is_dir() and not d.name.startswith(".")
+            }
+            repo_sets.append(repos)
+
+    pyprojects, req_files = find_dependency_files(image_repo)
+    all_files = pyprojects + req_files
+
+    package_sources = {}
+
+    for pp in pyprojects:
+        rel = str(pp.relative_to(image_repo))
+        for pkg in parse_pyproject_toml(pp):
+            package_sources.setdefault(pkg, set()).add(rel)
+
+    for rf in req_files:
+        rel = str(rf.relative_to(image_repo))
+        for pkg in parse_requirements_txt(rf):
+            package_sources.setdefault(pkg, set()).add(rel)
+
+    matched = {}
+    unmatched = []
+
+    for pkg in sorted(package_sources):
+        repo, method = find_repo(pkg, repo_sets)
+        if repo:
+            if repo not in matched:
+                matched[repo] = {
+                    "repo": repo,
+                    "match_method": method,
+                    "packages": [],
+                    "found_in": set(),
+                }
+            matched[repo]["packages"].append(pkg)
+            matched[repo]["found_in"].update(package_sources[pkg])
+        else:
+            unmatched.append(pkg)
+
+    for repo_info in matched.values():
+        repo_info["found_in"] = sorted(repo_info["found_in"])
+
+    result = {
+        "image_repo": str(image_repo),
+        "files_scanned": len(all_files),
+        "total_packages": len(package_sources),
+        "matched_repos": len(matched),
+        "unmatched_packages": len(unmatched),
+        "repos": matched,
+        "unmatched": unmatched,
+    }
+
+    print(json.dumps(result, indent=2, default=list))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/discover-components/scripts/parse_image_dependencies.py
+++ b/.claude/skills/discover-components/scripts/parse_image_dependencies.py
@@ -14,6 +14,7 @@ Output: JSON with matched repos, unmatched packages, and metadata.
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 KNOWN_MAPPINGS = {
@@ -108,31 +109,26 @@ def parse_pyproject_toml(filepath):
     """Extract package names from a pyproject.toml dependencies list."""
     packages = set()
     try:
-        content = filepath.read_text()
-    except (OSError, UnicodeDecodeError):
+        data = tomllib.loads(filepath.read_text())
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
         return packages
 
-    in_deps = False
-    for line in content.splitlines():
-        stripped = line.strip()
+    for dep in data.get("project", {}).get("dependencies", []):
+        name = extract_package_name(dep)
+        if name:
+            packages.add(name)
 
-        if stripped in (
-            "dependencies = [",
-            "override-dependencies = [",
-        ):
-            in_deps = True
-            continue
+    for dep in data.get("project", {}).get("override-dependencies", []):
+        name = extract_package_name(dep)
+        if name:
+            packages.add(name)
 
-        if in_deps:
-            if stripped == "]":
-                in_deps = False
-                continue
-
-            match = re.search(r'"([^"]+)"', stripped)
-            if match:
-                name = extract_package_name(match.group(1))
-                if name:
-                    packages.add(name)
+    for dep in (
+        data.get("tool", {}).get("uv", {}).get("override-dependencies", [])
+    ):
+        name = extract_package_name(dep)
+        if name:
+            packages.add(name)
 
     return packages
 

--- a/.claude/skills/discover-components/scripts/validate_component_map.py
+++ b/.claude/skills/discover-components/scripts/validate_component_map.py
@@ -19,7 +19,7 @@ VALID_DISCOVERY_METHODS = {"breadcrumb"}
 
 VALID_DISCOVERED_VIA = {
     "operator_operand", "operator_bundle",
-    "container_image", "dependency", "installer", "dsc_spec",
+    "container_image", "image_dependency", "dependency", "installer", "dsc_spec",
 }
 
 VALID_CONFIDENCE = {"high", "medium", "low", "disputed"}


### PR DESCRIPTION
Add parse_image_dependencies.py script that scans pyproject.toml and requirements*.txt in image-building repos (e.g. notebooks) and matches Python package names against checkout repos. This closes the discovery gap where components shipped as pip dependencies inside container images (like codeflare-sdk) were missed by DSC-spec and RELATED_IMAGE logic.

Add Step 5.1c to SKILL.md with binding rule, and add "image_dependency" to the validator's VALID_DISCOVERED_VIA set.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image-dependency discovery by scanning Python dependency files in image-build repos and mapping discovered packages to existing repositories.
  * Generated discovery results now record `discovered_via: "image_dependency"` and apply tiering/binding for all matched repos.
* **Documentation**
  * Updated the discovery guide with the new image-dependency step and clarified release-catalog version lookup (falls back to the latest available version).
* **Bug Fixes**
  * Updated component-map validation and the output JSON schema to recognize the new `image_dependency` component type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->