### PR TITLE
fix: correct kubeflow package mappings in image dependency discovery

### DIFF
--- a/.claude/skills/discover-components/scripts/parse_image_dependencies.py
+++ b/.claude/skills/discover-components/scripts/parse_image_dependencies.py
@@ -21,6 +21,8 @@ KNOWN_MAPPINGS = {
     "codeflare-sdk": "codeflare-sdk",
     "kfp": "data-science-pipelines",
     "kfp-server-api": "data-science-pipelines",
+    "kubeflow-kale": "kubeflow-kale",
+    "kubeflow-training": "training-operator",
     "mlflow": "mlflow",
     "ray": "kuberay",
 }
@@ -38,6 +40,7 @@ def find_repo(name, repo_sets):
         for repos in repo_sets:
             if mapped in repos:
                 return mapped, "known_mapping"
+        return None, None
 
     for repos in repo_sets:
         if name in repos:

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -136,6 +136,8 @@ rhoai-3.5-ea.2:
   extra_repos:
     - org: project-codeflare
       repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
     - org: Red-Hat-AI-Innovation-Team
@@ -156,6 +158,10 @@ rhoai-3.5-ea.2:
       repo_org: IBM
       repo_name: ai4rag
       type: library
+    - key: kubeflow-sdk
+      repo_org: opendatahub-io
+      repo_name: kubeflow-sdk
+      type: shared_library
     - key: training-hub
       repo_org: Red-Hat-AI-Innovation-Team
       repo_name: training_hub


### PR DESCRIPTION
Add KNOWN_MAPPINGS for kubeflow-training (maps to training-operator) and kubeflow-kale (no midstream repo, should be unmatched). Without these, both falsely matched the kubeflow shared library repo via parent_repo fallback. Also make find_repo return early when a KNOWN_MAPPINGS entry doesn't find its target, preventing the parent_repo heuristic from overriding explicit mappings.

Add missing kubeflow-sdk to rhoai-3.5-ea.2 platform definition.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded platform support to include an additional shared library component and fetch its related repository during setup.
  * Improved repository matching for component discovery, including better handling of specific Kubeflow project names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->