### PR TITLE
Add lint-architecture-docs script and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,18 @@ jobs:
       - name: Lint platforms.yaml
         run: make lint-platforms
 
+  lint-architecture-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Lint architecture docs
+        run: make lint-architecture-docs
+
   lint-go:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-embedded test clean lint lint-python lint-go lint-overlays lint-platforms
+.PHONY: build build-embedded test clean lint lint-python lint-go lint-overlays lint-platforms lint-architecture-docs
 
 build:
 	$(MAKE) -C src/arch-query build
@@ -12,7 +12,7 @@ test:
 clean:
 	$(MAKE) -C src/arch-query clean
 
-lint: lint-python lint-go lint-overlays lint-platforms
+lint: lint-python lint-go lint-overlays lint-platforms lint-architecture-docs
 
 lint-python:
 	uv run ruff check .
@@ -25,3 +25,6 @@ lint-overlays:
 
 lint-platforms:
 	uv run python scripts/lint_platforms.py
+
+lint-architecture-docs:
+	uv run python scripts/lint_architecture_docs.py

--- a/scripts/lint_architecture_docs.py
+++ b/scripts/lint_architecture_docs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate generated component architecture Markdown files under architecture/."""
+
+import sys
+from pathlib import Path
+
+ARCHITECTURE_DIR = Path(__file__).resolve().parent.parent / "architecture"
+
+SKIP_NAMES = {"PLATFORM.md", "README.md"}
+
+REQUIRED_SECTIONS = [
+    "Metadata",
+    "Purpose",
+    "Architecture Components",
+    "APIs Exposed",
+    "Dependencies",
+    "Network Architecture",
+    "Security",
+    "Data Flows",
+    "Integration Points",
+    "Recent Changes",
+]
+
+
+def find_sections(text: str) -> set[str]:
+    sections: set[str] = set()
+    for line in text.splitlines():
+        if line.startswith("## "):
+            sections.add(line[3:].strip())
+    return sections
+
+
+def validate_component_doc(path: Path) -> list[str]:
+    errors: list[str] = []
+    sections = find_sections(path.read_text())
+    for section in REQUIRED_SECTIONS:
+        if section not in sections:
+            errors.append(f"missing required section: ## {section}")
+    return errors
+
+
+def main() -> int:
+    arch_dir = ARCHITECTURE_DIR
+    if not arch_dir.is_dir():
+        print(f"architecture directory not found: {arch_dir}")
+        return 1
+
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for path in sorted(arch_dir.glob("*/*.md")):
+        real = path.resolve()
+        if real in seen:
+            continue
+        seen.add(real)
+        if path.name in SKIP_NAMES:
+            continue
+        files.append(path)
+
+    if not files:
+        print("No component architecture files found.")
+        return 0
+
+    total_errors = 0
+    for path in files:
+        for error in validate_component_doc(path):
+            print(f"{path.relative_to(arch_dir.parent)}: {error}")
+            total_errors += 1
+
+    if total_errors:
+        print(f"\n{total_errors} error(s) found in {len(files)} file(s)")
+        return 1
+
+    print(f"All {len(files)} component architecture file(s) passed validation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_architecture_docs.py
+++ b/scripts/lint_architecture_docs.py
@@ -48,12 +48,12 @@ def main() -> int:
     seen: set[Path] = set()
     files: list[Path] = []
     for path in sorted(arch_dir.glob("*/*.md")):
+        if path.name in SKIP_NAMES:
+            continue
         real = path.resolve()
         if real in seen:
             continue
         seen.add(real)
-        if path.name in SKIP_NAMES:
-            continue
         files.append(path)
 
     if not files:


### PR DESCRIPTION
## Summary

Adds a linter that validates generated component architecture Markdown files under `architecture/`, mirroring the style of `lint_overlays.py` and `lint_platforms.py`.

## Changes

- `scripts/lint_architecture_docs.py` — validates that each component doc contains all required sections:
  - `## Metadata`
  - `## Purpose`
  - `## Architecture Components`
  - `## APIs Exposed`
  - `## Dependencies`
  - `## Network Architecture`
  - `## Security`
  - `## Data Flows`
  - `## Integration Points`
  - `## Recent Changes`
- Handles symlink deduplication so version alias symlinks are not double-counted.
- `Makefile` — adds `lint-architecture-docs` target and includes it in the aggregate `lint` target.
- `.github/workflows/ci.yml` — adds a `lint-architecture-docs` CI job using pinned SHA hashes, consistent with the existing lint jobs.

## Validation

Tested locally:

```bash
uv run python scripts/lint_architecture_docs.py
make lint-architecture-docs
uv run ruff check scripts/lint_architecture_docs.py
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for architecture documentation as part of the standard validation process.
* **Bug Fixes**
  * Improved build validation to catch missing or incomplete architecture doc sections earlier.
* **Chores**
  * Updated the main lint workflow to include the new documentation lint step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->