### PR TITLE
fix: include JSON data and CRD schemas in embedded arch-query binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
             name=$(basename "$d")
             if [ ! -L "../../architecture/$name" ]; then
               mkdir -p "_embedded/architecture/$name"
-              find "$d" -maxdepth 1 -name '*.md' -exec cp {} "_embedded/architecture/$name/" \;
+              find "$d" -maxdepth 1 \( -name '*.md' -o -name '*.json' \) -exec cp {} "_embedded/architecture/$name/" \;
+              if [ -d "$d/contracts" ]; then
+                cp -r "$d/contracts" "_embedded/architecture/$name/contracts"
+              fi
             fi
           done
           python3 -c "import os,json; d='../../architecture'; \

--- a/src/arch-query/Makefile
+++ b/src/arch-query/Makefile
@@ -11,12 +11,15 @@ build:
 build-embedded:
 	rm -rf _embedded/architecture
 	mkdir -p _embedded/architecture
-	@# Copy only .md files from real version directories (skip symlinks, diagrams, JSON)
+	@# Copy .md and .json files from real version directories (skip symlinks and diagrams)
 	@for d in $(ARCH_DIR)/*/; do \
 		name=$$(basename "$$d"); \
 		if [ ! -L "$(ARCH_DIR)/$$name" ]; then \
 			mkdir -p "_embedded/architecture/$$name"; \
-			find "$$d" -maxdepth 1 -name '*.md' -exec cp {} "_embedded/architecture/$$name/" \; ; \
+			find "$$d" -maxdepth 1 \( -name '*.md' -o -name '*.json' \) -exec cp {} "_embedded/architecture/$$name/" \; ; \
+			if [ -d "$$d/contracts" ]; then \
+				cp -r "$$d/contracts" "_embedded/architecture/$$name/contracts"; \
+			fi; \
 		fi; \
 	done
 	@python3 -c "import os,json; d='$(ARCH_DIR)'; \
@@ -62,6 +65,16 @@ smoke-embedded: build-embedded
 	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) search vllm
 	@echo "---"
 	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) --version current-ga list --names-only | wc -l
+	@echo "---"
+	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) webhooks | head -5
+	@echo "---"
+	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) watches | head -5
+	@echo "---"
+	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) provenance --upstream-only | head -5
+	@echo "---"
+	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) schemas | head -5
+	@echo "---"
+	cd /tmp && $(CURDIR)/$(BUILD_DIR)/$(BINARY) images | head -5
 
 lint:
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run ./...


### PR DESCRIPTION
The build-embedded staging step previously copied only *.md files from each version directory into the _embedded/architecture tree. This meant the self-contained binary was missing several data sources that the runtime code already knows how to load through the fs.FS interface:

  - Per-component arch-analyzer JSON (*.json) — supplies controller watches, webhooks, network policies, dockerfiles, RBAC markers, HTTP endpoints, and commit/version metadata that mergeJSON() merges into the markdown-parsed ComponentDoc.

  - component-map.json — provides the component-to-repo mapping used by the `provenance` command (LoadComponentRepoMapping) and the provenance metadata loaded by loadProvenance().

  - build-info.json — contains the container image manifest consumed by the `images` command via loadBuildInfo().

  - webhooks.json — platform-wide webhook aggregation data.

  - contracts/schemas/<component>/*.json — CRD JSON schemas extracted by arch-analyzer's extract-schema, served by the `schemas` command.

Without these files, running the embedded binary from a location with no local architecture/ directory caused `webhooks`, `watches`, `provenance`, `schemas`, and `images` to return empty or degraded output, even though the Go code paths were fully wired up.

Changes:

  src/arch-query/Makefile:
    - Expand the find command in build-embedded from `-name '*.md'` to `\( -name '*.md' -o -name '*.json' \)` so all JSON files at the version directory root are staged.
    - Add a conditional `cp -r` of the contracts/ subdirectory when it exists, preserving the contracts/schemas/<component>/ tree.
    - Add smoke-embedded checks for webhooks, watches, provenance, schemas, and images commands to catch regressions.

  .github/workflows/release.yml:
    - Mirror the same staging changes in the release workflow's "Stage embedded data" step, which duplicates the Makefile logic for cross-platform CI builds.

No Go source changes were required — the runtime already loads all these data types via fs.FS; only the build-time staging was incomplete.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Packaged embedded architecture data now includes additional JSON files and contract assets, making more architecture details available in released builds.

* **Tests**
  * Expanded embedded smoke checks to cover more architecture queries, improving validation of packaged content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->