### PR TITLE
docs: Add tenancy model for RHOAI Dashboard

### DIFF
--- a/architecture/rhoai.next/dashboard-tenancy.md
+++ b/architecture/rhoai.next/dashboard-tenancy.md
@@ -75,9 +75,10 @@ These permissions are used only for SA-privileged operations, not for user reque
 | Gap | Impact | Severity |
 |-----|--------|----------|
 | Dashboard SA ClusterRole breadth | `rhods-dashboard` ClusterRole grants `create/delete` on secrets, configmaps, PVCs, notebooks, rolebindings, clusterrolebindings, and roles cluster-wide. SA-privileged operations are gated by SSAR checks. A bug in SSAR gating logic would expose these privileges across all namespaces. | P0 |
-| No per-tenant dashboard configuration | `OdhDashboardConfig` is a platform-wide singleton. All tenants share the same feature flags, admin groups, and visibility settings. | P1 |
 | BFF sidecars share pod network namespace | All BFF sidecars and the Node.js backend share a pod network namespace. A compromised BFF can reach all other sidecars on localhost. Mitigated by token isolation (separate projected tokens). | P1 |
 | Dashboard logs may contain cross-tenant information | Pod logs from the shared pod may include request information from all users. No per-tenant log filtering. | P2 |
+
+**Note on `OdhDashboardConfig`:** The `OdhDashboardConfig` CR is a platform-wide singleton managed by the RHOAI admin. This is by design — the platform admin configures feature flags, admin groups, and visibility settings for the entire platform. Tenant isolation is achieved through namespace-scoped RBAC (users see different resources based on their permissions), not through per-tenant dashboard configuration.
 
 ## Cross-Component Interactions
 

--- a/architecture/rhoai.next/dashboard-tenancy.md
+++ b/architecture/rhoai.next/dashboard-tenancy.md
@@ -1,0 +1,90 @@
+# RHOAI Dashboard -- Multi-Tenancy Model
+
+**Audit Ticket:** [RHOAIENG-76368](https://redhat.atlassian.net/browse/RHOAIENG-76368)
+**Date:** 2026-07-20
+**Auditor:** Jeff Young
+
+## Tenant Definition
+
+In the RHOAI Dashboard, a **tenant** is a user with RBAC access to one or more Kubernetes namespaces (Data Science Projects). The dashboard scopes resource visibility by forwarding the user's own bearer token (from `x-forwarded-access-token`) to the K8s API — the API server evaluates the user's own RBAC, not the dashboard SA's permissions. Users see only resources in namespaces their RBAC allows.
+
+The dashboard does not deploy per-tenant infrastructure. It runs as a single shared pod in the platform namespace (`redhat-ods-applications`) serving all users.
+
+## Isolation Mechanisms
+
+### Token Forwarding (Core Tenancy Mechanism)
+
+The dashboard uses the **user's forwarded bearer token** for K8s API calls:
+
+1. kube-rbac-proxy (port 8443) authenticates the user (SAR: `list` on `projects`), forwards token via `x-forwarded-access-token`
+2. Node.js backend extracts the token and uses it as `Authorization: Bearer <token>` for K8s API calls
+3. K8s API server evaluates the user's own RBAC — the dashboard SA's permissions are not used for user requests
+4. For service proxies (DSP, Model Registry, MLflow), the user's token is forwarded to the upstream service
+
+This is **direct token forwarding**, not K8s impersonation (no impersonation headers are set).
+
+### SA-Privileged Operations
+
+Some operations use the **dashboard SA token** instead of the user's token, gated by SubjectAccessReview checks:
+
+| Operation | SA Permission Used | SSAR Gate |
+|-----------|-------------------|-----------|
+| Notebook CR creation | `create` on `notebooks.kubeflow.org` | User can create notebooks in the namespace |
+| Per-user RoleBinding creation | `create` on `rolebindings` | User has namespace access |
+| Namespace labeling (`opendatahub.io/dashboard=true`) | `patch` on `namespaces` | User can `update` projects |
+| Admin cluster settings | Various | User can `patch` the `Auth` singleton CR |
+
+### Authentication
+
+Four-layer chain:
+1. **Gateway** — TLS termination
+2. **kube-rbac-proxy** — SAR: user can `list` projects in `project.openshift.io`. Sets `X-Auth-Request-User` and `X-Auth-Request-Groups` headers.
+3. **Node.js backend** — extracts user token from `x-forwarded-access-token`
+4. **BFF sidecars** — receive user token, use for upstream calls
+
+### RBAC
+
+The `rhods-dashboard` ClusterRole grants the dashboard SA:
+
+| Resource | Verbs | Notes |
+|----------|-------|-------|
+| secrets, configmaps, PVCs | `create/delete/get/list/patch/update/watch` | Full CRUD including delete |
+| notebooks (`kubeflow.org`) | `create/delete/get/list/patch/update/watch` | Full CRUD including delete |
+| rolebindings, clusterrolebindings, roles | `create/delete/get/list/patch` | No `update` or `watch` |
+| namespaces | `patch` only | Namespace labeling |
+| storageclasses | `patch/update` only | No create/delete |
+| nodes, users, groups | `get/list` (+ `watch` for users/groups) | Read-only |
+
+These permissions are used only for SA-privileged operations, not for user requests (which use the user's own token).
+
+### Network Isolation
+
+- NetworkPolicies for the dashboard pod and per-BFF-module NetworkPolicies
+- External access via HTTPRoute on port 8443 through the Gateway
+- Pod-internal: kube-rbac-proxy to Node.js backend over HTTP (localhost); Node.js to BFF sidecars over HTTPS with TLS
+- No dashboard-created egress NetworkPolicies. The dashboard proxies to many platform services (DSP, Model Registry, MLflow, KServe, Prometheus). Cluster-wide policies may restrict egress independently.
+
+### Token Isolation
+
+- `automountServiceAccountToken: false` on the pod spec
+- Separate projected tokens: `dashboard-sa-token` for core containers (Node.js + kube-rbac-proxy), `modules-sa-token` for BFF sidecars
+- Limits blast radius if a BFF sidecar is compromised
+
+## Known Gaps
+
+| Gap | Impact | Severity |
+|-----|--------|----------|
+| Dashboard SA ClusterRole breadth | `rhods-dashboard` ClusterRole grants `create/delete` on secrets, configmaps, PVCs, notebooks, rolebindings, clusterrolebindings, and roles cluster-wide. SA-privileged operations are gated by SSAR checks. A bug in SSAR gating logic would expose these privileges across all namespaces. | P0 |
+| No per-tenant dashboard configuration | `OdhDashboardConfig` is a platform-wide singleton. All tenants share the same feature flags, admin groups, and visibility settings. | P1 |
+| BFF sidecars share pod network namespace | All BFF sidecars and the Node.js backend share a pod network namespace. A compromised BFF can reach all other sidecars on localhost. Mitigated by token isolation (separate projected tokens). | P1 |
+| Dashboard logs may contain cross-tenant information | Pod logs from the shared pod may include request information from all users. No per-tenant log filtering. | P2 |
+
+## Cross-Component Interactions
+
+| RHOAI Component | Integration | Tenancy Implications |
+|-----------------|-------------|----------------------|
+| Kubeflow Notebooks | Creates Notebook CRs using SA token (gated by SSAR). Creates per-user Role and RoleBinding giving the user `get` access to their specific notebook. | SA-privileged creation. SSAR bypass would allow creating notebooks in any namespace. |
+| Data Science Pipelines | Service proxy: forwards user's token to DSPA API. SSAR check verifies user can `GET` the DSPA CR before proxying. | User's token forwarded — DSPA's kube-rbac-proxy handles authorization. |
+| MLflow | MLflow BFF proxies user's token to MLflow tracking server. Dashboard manages global MLflow workspace namespace labels (admin-only). | User's token forwarded — MLflow's kubernetes-auth SSAR handles authorization. |
+| Model Registry | REST proxy + CRD management with user's token. | User's token forwarded — Model Registry's auth handles authorization. |
+| KServe | K8s API pass-through with user's token. | K8s RBAC evaluated on user's identity. |

--- a/architecture/rhoai.next/odh-dashboard.md
+++ b/architecture/rhoai.next/odh-dashboard.md
@@ -727,7 +727,8 @@ The dashboard uses a **token forwarding** model for multi-tenancy. For the full 
 
 **Key risks:**
 - The `rhods-dashboard` ClusterRole grants `create/delete/get/list/patch/update/watch` on secrets, configmaps, PVCs, and notebooks cluster-wide; `create/delete/get/list/patch` on rolebindings, clusterrolebindings, and roles. SA-privileged operations are SSAR-gated — a bug in the gating logic would expose these privileges.
-- No per-tenant dashboard configuration (`OdhDashboardConfig` is a singleton).
+
+**Note:** `OdhDashboardConfig` is a platform-wide singleton managed by the RHOAI admin. Tenant isolation is through namespace-scoped RBAC, not per-tenant dashboard configuration.
 
 ## Architectural Analysis
 

--- a/architecture/rhoai.next/odh-dashboard.md
+++ b/architecture/rhoai.next/odh-dashboard.md
@@ -711,6 +711,24 @@ This component defines 3 webhook(s) (0 mutating, 2 validating, 1 conversion).
 | cert-manager | Certificate CR | N/A | N/A | N/A | Webhook and metrics TLS (operator) |
 | MaaS BFF (inter-BFF) | REST | 8243/TCP | HTTPS | TLS 1.2+ | Token management from gen-ai |
 
+## Multi-Tenancy Model
+
+The dashboard uses a **token forwarding** model for multi-tenancy. For the full tenancy audit, see [dashboard-tenancy.md](dashboard-tenancy.md) ([RHOAIENG-76368](https://redhat.atlassian.net/browse/RHOAIENG-76368)).
+
+| Aspect | Implementation |
+|--------|----------------|
+| **Tenant boundary** | Per-user: user's own K8s RBAC determines resource visibility |
+| **Deployment model** | Single shared pod in the platform namespace serving all users |
+| **Core mechanism** | User's bearer token forwarded via `x-forwarded-access-token` to K8s API. API server evaluates user's own RBAC. Not K8s impersonation. |
+| **Authentication** | kube-rbac-proxy SAR: user can `list` projects. Token forwarded to backend and BFF sidecars. |
+| **SA-privileged operations** | Notebook CR creation, per-user RoleBinding creation, namespace labeling — gated by SSAR checks against user's token |
+| **Configuration** | `OdhDashboardConfig` — platform-wide singleton. No per-tenant configuration. |
+| **Token isolation** | Separate projected tokens: `dashboard-sa-token` for core containers, `modules-sa-token` for BFF sidecars |
+
+**Key risks:**
+- The `rhods-dashboard` ClusterRole grants `create/delete/get/list/patch/update/watch` on secrets, configmaps, PVCs, and notebooks cluster-wide; `create/delete/get/list/patch` on rolebindings, clusterrolebindings, and roles. SA-privileged operations are SSAR-gated — a bug in the gating logic would expose these privileges.
+- No per-tenant dashboard configuration (`OdhDashboardConfig` is a singleton).
+
 ## Architectural Analysis
 
 The odh-dashboard represents one of the more architecturally sophisticated components in the RHOAI platform, implementing a full micro-frontend architecture using Webpack Module Federation. The host application (`frontend/` + `backend/`) provides the shell (navigation, routing, header) while feature-specific packages are loaded as federated remotes at runtime. This design enables independent deployment and development of feature areas like generative AI, model-as-a-service, and model registry without requiring a full dashboard rebuild.


### PR DESCRIPTION
## Description

[RHOAIENG-76368](https://redhat.atlassian.net/browse/RHOAIENG-76368)

Add dashboard-tenancy.md documenting the multi-tenancy model for the RHOAI Dashboard, including the token forwarding mechanism (user's bearer token forwarded to K8s API, not K8s impersonation), SA-privileged operations inventory with SSAR gating, cluster-verified RBAC verbs, known gaps, and cross-component interactions. Add a Multi-Tenancy Model summary section to the existing odh-dashboard.md linking to the detailed audit.

## How Has This Been Tested?

Dashboard SA ClusterRole verbs verified on a live RHOAI 3.5 EA2 cluster:
- `rhods-dashboard` ClusterRole verbs confirmed per resource (secrets: `create/delete/get/list/patch/update/watch`; rolebindings/clusterrolebindings/roles: `create/delete/get/list/patch` without `update` or `watch`; namespaces: `patch` only)
- Token forwarding model verified by reading `directCallUtils.ts` source — user's token from `x-forwarded-access-token` header used as `Authorization: Bearer` for K8s API calls (not K8s impersonation headers)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-76368]: https://redhat.atlassian.net/browse/RHOAIENG-76368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the dashboard’s multi-tenancy model and tenant boundaries.
  * Documented authentication, authorization, token forwarding, and isolation mechanisms.
  * Clarified service-account-privileged operations and permission checks.
  * Added details on network isolation, component interactions, configuration scope, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->