### PR TITLE
Document LLMInferenceServiceConfig versioning, accelerator presets, and deletion protection

### DIFF
--- a/overlays/0011-kserve-llm-d-architecture.md
+++ b/overlays/0011-kserve-llm-d-architecture.md
@@ -23,16 +23,15 @@ superseded_by: null
 
 ## Fact
 
-KServe v1alpha2 introduces **LLMInferenceService** (`serving.kserve.io/v1alpha2`, short name `llmisvc`), a purpose-built
+KServe introduces **LLMInferenceService** (`serving.kserve.io`, short name `llmisvc`), a purpose-built
 CRD for LLM deployments that deeply integrates the **llm-d** distributed inference stack. Unlike the general-purpose
 InferenceService (v1beta1), LLMInferenceService is designed exclusively for LLM workloads and natively manages the llm-d
 router (EPP), disaggregated prefill/decode topology, multi-node LeaderWorkerSet deployments, and LLM-specific
-autoscaling via the Workload Variant Autoscaler (WVA).
+autoscaling via the Workload Variant Autoscaler (WVA) and KEDA.
 
-llm-d is a CNCF Sandbox project (founded by Red Hat, Google Cloud, IBM Research, CoreWeave, NVIDIA) providing
-state-of-the-art distributed LLM inference serving on Kubernetes. Its core Go components live in separate repositories:
-`llm-d-inference-scheduler` (EPP), `llm-d-kv-cache` (KV indexer/offloader), `llm-d-workload-variant-autoscaler` (WVA),
-`llm-d-routing-sidecar` (P/D coordination), `llm-d-latency-predictor`, `llm-d-async`, and `batch-gateway`.
+llm-d is a CNCF Sandbox project providing state-of-the-art distributed LLM inference serving on Kubernetes. Its core Go
+components live in separate repositories: `llm-d-router` (EPP and P/D routing sidecar coordination),
+`llm-d-workload-variant-autoscaler` (WVA), `llm-d-latency-predictor`, `llm-d-async`, and `batch-gateway`.
 
 ### CRD and API Surface
 
@@ -54,6 +53,21 @@ spec fields:
 **LLMInferenceServiceConfig** (`llminferenceserviceconfigs.serving.kserve.io`) is a companion CRD acting as a reusable
 configuration template. Multiple LLMInferenceService instances can reference configs via `spec.baseRefs`; the last
 config in the list wins on conflicts, and inline spec fields always take highest precedence.
+
+#### Deletion Protection
+
+A dedicated `LLMISVCConfigReconciler` manages a finalizer (`serving.kserve.io/llmisvcconfig-finalizer`) that prevents
+deletion of configs still in use. A config is considered referenced if any `LLMInferenceService` mentions it via
+`spec.baseRefs`, `status.annotations` (versioned config pins), or implicitly as a well-known default config. System-
+namespace configs are checked against all namespaces cluster-wide; user-namespace configs are checked within their own
+namespace only.
+
+The controller maintains a `ConfigInUse` status condition reflecting the current reference state at all times (not only
+during deletion). When deletion is attempted on a referenced config, the finalizer is retained and a `DeletionBlocked`
+warning event is emitted. The finalizer is removed — and deletion proceeds — once no references remain.
+
+Well-known configs in the system namespace are additionally hard-blocked from deletion by a validating webhook,
+independent of the finalizer.
 
 ### Deployment Topologies
 
@@ -228,6 +242,10 @@ gateway topology and scheduler references.
 
 ### LLMInferenceServiceConfig Presets (managed in KServe)
 
+See also: [Overlay 0022](0022-kserve-llm-d-versioned-base-llminferenceserviceconfig.md) for the versioned base
+config naming scheme that enables revision management across RHOAI upgrades without cloning configs into user
+namespaces.
+
 KServe ships 8 `LLMInferenceServiceConfig` CRs in `config/llmisvcconfig/` (deployed via Kustomize into the `kserve`
 namespace). These presets define the default container specs, scheduler deployment, and routing configuration — they are
 the authoritative source for default llm-d component images, ports, probes, and EPP sidecar composition:
@@ -245,6 +263,51 @@ the authoritative source for default llm-d component images, ports, probes, and 
 
 Templates use Go templating (`.ObjectMeta.Name`, `.GlobalConfig.*`, `.Spec.*`) and support RoCE networking
 auto-detection, TLS cert injection, and multiple accelerator types.
+
+### Accelerator-Specific LLMInferenceServiceConfig Presets
+
+On top of the generic base templates, the ODH overlay (`config/overlays/odh/accelerators/`) ships accelerator-specific
+`LLMInferenceServiceConfig` resources. These are thin configs that declare only the accelerator-specific deltas — name,
+annotations, container image, and optional environment variables or scheduler overrides. The base template provides the
+full container definition (entrypoint, probes, volumes, security context); accelerator presets specialize it for
+specific hardware.
+
+Each accelerator type has one config per supported deployment topology (single-node, P/D, multi-node, multi-node P/D).
+The naming convention is `kserve-config-llm-<topology>-template-<accelerator>`. Not every accelerator supports every
+topology — check `config/overlays/odh/accelerators/` for the current matrix.
+
+Some accelerators require more than just image substitution. For example, IBM Spyre configs set
+accelerator-specific environment variables and a custom `schedulerName`, in addition to the container image.
+
+#### Annotations on Accelerator Configs
+
+Each accelerator config carries metadata annotations consumed by the Dashboard and operator:
+
+| Annotation                                | Purpose                                                             |
+|-------------------------------------------|---------------------------------------------------------------------|
+| `opendatahub.io/recommended-accelerators` | JSON array of Kubernetes device resource names for this accelerator |
+| `opendatahub.io/supported-topologies`     | JSON array of topology identifiers this config supports             |
+| `opendatahub.io/runtime-version`          | Upstream runtime version string, stamped at build time from SBOM    |
+| `serving.kserve.io/well-known-config`     | Marks as a platform-managed config (applied via JSON patch)         |
+
+The label `opendatahub.io/config-type: accelerator` is applied to all accelerator configs via `commonLabels`.
+
+#### Kustomize Composition: Base + Accelerator Preset + Fast Channel
+
+The accelerator config system uses a three-layer Kustomize composition:
+
+1. **Base layer** (`config/llmisvcconfig/`): Full, generic `LLMInferenceServiceConfig` templates with an upstream
+   placeholder image. Contains the complete container spec — entrypoint, probes, volumes, security context.
+
+2. **Accelerator presets** (`config/overlays/odh/accelerators/`): Thin `LLMInferenceServiceConfig` resources that
+   declare the accelerator-specific name, annotations, and `image: placeholder` fields. Container images are injected
+   via Kustomize `replacements` from `params.env`, keyed by accelerator type. Runtime version annotations are
+   similarly stamped from `params.env`.
+
+3. **Fast channels** (`config/overlays/odh/accelerators-fast/`): Reuses the same accelerator presets as a Kustomize
+   base and applies `nameSuffix` (e.g., `-fast-1`) and fast-version annotations. This produces parallel sets of
+   resources marked `opendatahub.io/support-status: unsupported`. Fast channels can carry early-access builds
+   independently of the base channel.
 
 ### odh-model-controller: Kuadrant Security Integration for LLMInferenceService
 
@@ -544,6 +607,21 @@ The distro build adds RBAC markers for OCP resources the controller manages:
 - Workload TLS on OCP uses OpenShift service-ca signing rather than self-signed certificates. The controller reads the
   CA signing secret from `openshift-service-ca` namespace. Strategies involving namespace restrictions or network
   policies must allow the KServe controller cross-namespace read access to this secret.
+- Accelerator-specific `LLMInferenceServiceConfig` presets determine which runtime image and hardware configuration a
+  deployment receives. Not all accelerators support all topologies — check the accelerator matrix before planning
+  multi-node or disaggregated deployments on non-default hardware.
+- The fast-channel mechanism provides an early-access path for new runtime builds without modifying the base channel.
+  Fast-channel configs are marked unsupported and can diverge from base-channel images independently.
+- Some accelerators (e.g., IBM Spyre) require more than image substitution — they set accelerator-specific environment
+  variables and custom schedulers. Strategies targeting these accelerators must ensure the required infrastructure is
+  installed.
+- The `opendatahub.io/recommended-accelerators` and `opendatahub.io/supported-topologies` annotations are consumed by
+  the Dashboard for accelerator and topology selection. New accelerator types must include these for discoverability.
+- `LLMInferenceServiceConfig` deletion is protected by a finalizer and (for well-known configs) a webhook hard-block.
+  Operators must drain all referencing `LLMInferenceService` instances before a config can be removed. The `ConfigInUse`
+  condition provides runtime visibility into which configs are actively referenced.
+- When proposing APIs,
+  consider [Kubernetes API Conventions](https://raw.githubusercontent.com/kubernetes/community/refs/heads/main/contributors/devel/sig-architecture/api-conventions.md)
 
 ## Context
 

--- a/overlays/0011-kserve-llm-d-architecture.md
+++ b/overlays/0011-kserve-llm-d-architecture.md
@@ -64,7 +64,7 @@ namespace only.
 
 The controller maintains a `ConfigInUse` status condition reflecting the current reference state at all times (not only
 during deletion). When deletion is attempted on a referenced config, the finalizer is retained and a `DeletionBlocked`
-warning event is emitted. The finalizer is removed — and deletion proceeds — once no references remain.
+warning event is emitted. The finalizer is removed -- and deletion proceeds -- once no references remain.
 
 Well-known configs in the system namespace are additionally hard-blocked from deletion by a validating webhook,
 independent of the finalizer.
@@ -99,7 +99,7 @@ When `spec.router.scheduler` is configured, the controller creates a complete ll
 The EPP deployment uses `Recreate` strategy (not rolling update) because the EPP is stateful (prefix cache scorer
 state). For HA (`replicas > 1`), leader election is auto-enabled via `--ha-enable-leader-election`.
 
-Default scheduler configurations are managed in **KServe** — the KServe LLMInferenceService controller owns both the
+Default scheduler configurations are managed in **KServe** -- the KServe LLMInferenceService controller owns both the
 default `EndpointPickerConfig` generation and the scheduler Deployment template (`config-llm-scheduler` preset). When no
 explicit config is provided, the controller generates a default `EndpointPickerConfig` based on topology:
 
@@ -120,7 +120,7 @@ intervention:
 
 | Priority    | Source                                | Behavior                                                                                          |
 |-------------|---------------------------------------|---------------------------------------------------------------------------------------------------|
-| 1 (highest) | `spec.router.scheduler.config.inline` | Always wins — overwrites whatever is on the cluster                                               |
+| 1 (highest) | `spec.router.scheduler.config.inline` | Always wins -- overwrites whatever is on the cluster                                              |
 | 2           | Template container args               | If the preset template already carries `--config-text`, returns nil (no-op, avoids duplication)   |
 | 3           | Current deployment on cluster         | Reads `--config-text` from the *running* deployment's containers and carries it forward unchanged |
 | 4 (lowest)  | Fresh default generation              | `schedulerConfigText()` generates a topology-appropriate default only if nothing else exists      |
@@ -135,24 +135,24 @@ Migrations are applied as transforms on top of whichever config source was selec
 
 **Unconditional migrations** (applied regardless of scheduler version):
 
-| Migration                               | What it does                                                                                                |
-|-----------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| `WithUdsTokenizerConfig`                | Injects UDS tokenizer socket path and model name into `precise-prefix-cache-scorer` plugin                  |
-| `WithMigrateTokenProcessorConfig`       | Hoists `tokenProcessorConfig` from nested `indexerConfig` to top-level `parameters` (v0.6 schema fix)       |
-| `WithMigrateBlockSizeToBlockSizeTokens` | Renames deprecated `blockSize` (character count) → `blockSizeTokens` (token count) in `prefix-cache-scorer` |
+| Migration                               | What it does                                                                                                 |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `WithUdsTokenizerConfig`                | Injects UDS tokenizer socket path and model name into `precise-prefix-cache-scorer` plugin                   |
+| `WithMigrateTokenProcessorConfig`       | Hoists `tokenProcessorConfig` from nested `indexerConfig` to top-level `parameters` (v0.6 schema fix)        |
+| `WithMigrateBlockSizeToBlockSizeTokens` | Renames deprecated `blockSize` (character count) -> `blockSizeTokens` (token count) in `prefix-cache-scorer` |
 
-**Version-gated migrations** (only when scheduler image >= 0.7.0 — prevents v0.6 binaries from receiving config
+**Version-gated migrations** (only when scheduler image >= 0.7.0 -- prevents v0.6 binaries from receiving config
 they would reject):
 
-| Migration                         | What it does                                                                                                                                                          |
-|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `extractDeprecatedMetricFlags`    | Strips 5 metric CLI flags hard-rejected by GIE v1.4.0 and saves values for re-injection into config YAML                                                              |
-| `withMigrateDisaggHeadersHandler` | Plugin rename: `prefill-header-handler` → `disagg-headers-handler` (including `schedulingProfiles` references)                                                        |
-| `withMigrateDisaggProfileHandler` | Renames `pd-profile-handler` → `disagg-profile-handler`, migrates `deciderPluginName` → `deciders` map; skips if non-zero `threshold` is present (no v0.7 equivalent) |
-| `WithRemoveHashBlockSize`         | Removes deprecated `hashBlockSize` field from all plugins                                                                                                             |
-| `withCoreMetricsExtractorPlugin`  | Injects `core-metrics-extractor` plugin with parameters extracted from the removed CLI flags                                                                          |
+| Migration                         | What it does                                                                                                                                                           |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `extractDeprecatedMetricFlags`    | Strips 5 metric CLI flags hard-rejected by GIE v1.4.0 and saves values for re-injection into config YAML                                                               |
+| `withMigrateDisaggHeadersHandler` | Plugin rename: `prefill-header-handler` -> `disagg-headers-handler` (including `schedulingProfiles` references)                                                        |
+| `withMigrateDisaggProfileHandler` | Renames `pd-profile-handler` -> `disagg-profile-handler`, migrates `deciderPluginName` -> `deciders` map; skips if non-zero `threshold` present (no v0.7 equivalent)   |
+| `WithRemoveHashBlockSize`         | Removes deprecated `hashBlockSize` field from all plugins                                                                                                              |
+| `withCoreMetricsExtractorPlugin`  | Injects `core-metrics-extractor` plugin with parameters extracted from the removed CLI flags                                                                           |
 
-All migrations are idempotent — each checks whether the transformation has already been applied before modifying.
+All migrations are idempotent -- each checks whether the transformation has already been applied before modifying.
 The version gate reads the scheduler container image tag annotation to determine the running version.
 
 ### Request Flow
@@ -247,7 +247,7 @@ config naming scheme that enables revision management across RHOAI upgrades with
 namespaces.
 
 KServe ships 8 `LLMInferenceServiceConfig` CRs in `config/llmisvcconfig/` (deployed via Kustomize into the `kserve`
-namespace). These presets define the default container specs, scheduler deployment, and routing configuration — they are
+namespace). These presets define the default container specs, scheduler deployment, and routing configuration -- they are
 the authoritative source for default llm-d component images, ports, probes, and EPP sidecar composition:
 
 | Template                                  | Purpose                                                 |
@@ -267,14 +267,14 @@ auto-detection, TLS cert injection, and multiple accelerator types.
 ### Accelerator-Specific LLMInferenceServiceConfig Presets
 
 On top of the generic base templates, the ODH overlay (`config/overlays/odh/accelerators/`) ships accelerator-specific
-`LLMInferenceServiceConfig` resources. These are thin configs that declare only the accelerator-specific deltas — name,
+`LLMInferenceServiceConfig` resources. These are thin configs that declare only the accelerator-specific deltas -- name,
 annotations, container image, and optional environment variables or scheduler overrides. The base template provides the
 full container definition (entrypoint, probes, volumes, security context); accelerator presets specialize it for
 specific hardware.
 
 Each accelerator type has one config per supported deployment topology (single-node, P/D, multi-node, multi-node P/D).
 The naming convention is `kserve-config-llm-<topology>-template-<accelerator>`. Not every accelerator supports every
-topology — check `config/overlays/odh/accelerators/` for the current matrix.
+topology -- check `config/overlays/odh/accelerators/` for the current matrix.
 
 Some accelerators require more than just image substitution. For example, IBM Spyre configs set
 accelerator-specific environment variables and a custom `schedulerName`, in addition to the container image.
@@ -297,7 +297,7 @@ The label `opendatahub.io/config-type: accelerator` is applied to all accelerato
 The accelerator config system uses a three-layer Kustomize composition:
 
 1. **Base layer** (`config/llmisvcconfig/`): Full, generic `LLMInferenceServiceConfig` templates with an upstream
-   placeholder image. Contains the complete container spec — entrypoint, probes, volumes, security context.
+   placeholder image. Contains the complete container spec -- entrypoint, probes, volumes, security context.
 
 2. **Accelerator presets** (`config/overlays/odh/accelerators/`): Thin `LLMInferenceServiceConfig` resources that
    declare the accelerator-specific name, annotations, and `image: placeholder` fields. Container images are injected
@@ -305,9 +305,11 @@ The accelerator config system uses a three-layer Kustomize composition:
    similarly stamped from `params.env`.
 
 3. **Fast channels** (`config/overlays/odh/accelerators-fast/`): Reuses the same accelerator presets as a Kustomize
-   base and applies `nameSuffix` (e.g., `-fast-1`) and fast-version annotations. This produces parallel sets of
-   resources marked `opendatahub.io/support-status: unsupported`. Fast channels can carry early-access builds
-   independently of the base channel.
+   base and applies `nameSuffix` (e.g., `-fast-1`) and fast-version annotations. The version prefix is applied first
+   by the Operator, then the suffix, producing names like
+   `v3-2-0-kserve-config-llm-single-node-template-nvidia-cuda-fast-1`. Resources are marked
+   `opendatahub.io/support-status: unsupported`. Fast channels can carry early-access builds independently of the
+   base channel.
 
 ### odh-model-controller: Kuadrant Security Integration for LLMInferenceService
 
@@ -322,10 +324,10 @@ that run alongside the KServe LLMInferenceService controller and manage resource
 | **GatewayReconciler**             | `Gateway`             | `gateway-auth-bootstrap` | Creates EnvoyFilter + AuthPolicy on gateways used by LLMInferenceService |
 | **LLMInferenceServiceReconciler** | `LLMInferenceService` | `llminferenceservice`    | Creates AuthPolicy on HTTPRoutes for per-service auth control            |
 
-These controllers do not duplicate KServe's work — KServe manages Deployments, Services, InferencePools, and HTTPRoutes;
+These controllers do not duplicate KServe's work -- KServe manages Deployments, Services, InferencePools, and HTTPRoutes;
 odh-model-controller manages the Kuadrant security layer on top of the Gateway API resources KServe creates.
 
-#### GatewayReconciler — Gateway-Level Security Bootstrap
+#### GatewayReconciler -- Gateway-Level Security Bootstrap
 
 The GatewayReconciler watches Gateway resources and creates security resources when a gateway is "in use" by LLM
 inference. A gateway is considered in-use if:
@@ -356,19 +358,19 @@ Watch sources that trigger gateway reconciliation:
 The controller enforces Gateway API namespace isolation: before creating resources, it evaluates each gateway listener's
 `allowedRoutes` spec (`Same`, `All`, or `Selector`) against the LLMInferenceService namespace.
 
-#### LLMInferenceServiceReconciler — Per-Service HTTPRoute Auth
+#### LLMInferenceServiceReconciler -- Per-Service HTTPRoute Auth
 
 The LLMInferenceServiceReconciler watches LLMInferenceService resources and manages AuthPolicy resources on their
 HTTPRoutes. It:
 
 1. Fetches the LLMInferenceService and merges specs from BaseRef configs (reuses KServe's `MergeSpecs`)
-2. Resolves HTTPRoute names — from explicit `spec.router.route.http.refs` or the generated name `<name>-kserve-route`
+2. Resolves HTTPRoute names -- from explicit `spec.router.route.http.refs` or the generated name `<name>-kserve-route`
 3. Creates or deletes an AuthPolicy per HTTPRoute based on the auth annotation:
 
 | Annotation                            | Value              | HTTPRoute AuthPolicy                                  | Effect                                                                                               |
 |---------------------------------------|--------------------|-------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| `security.opendatahub.io/enable-auth` | absent or `"true"` | Not created (or deleted if it existed)                | Gateway-level **UserDefined** policy applies — Kubernetes TokenReview + SubjectAccessReview required |
-| `security.opendatahub.io/enable-auth` | `"false"`          | Created — **Anonymous** (`authpolicy_anonymous.yaml`) | Overrides gateway policy; unauthenticated access allowed                                             |
+| `security.opendatahub.io/enable-auth` | absent or `"true"` | Not created (or deleted if it existed)                | Gateway-level **UserDefined** policy applies -- Kubernetes TokenReview + SubjectAccessReview required|
+| `security.opendatahub.io/enable-auth` | `"false"`          | Created -- **Anonymous** (`authpolicy_anonymous.yaml`)| Overrides gateway policy; unauthenticated access allowed                                             |
 
 The default auth posture is **authenticated** (UserDefined). The gateway-level AuthPolicy requires a valid Kubernetes
 token and performs SubjectAccessReview authorization. Only when `enable-auth=false` is explicitly annotated does an
@@ -381,9 +383,9 @@ service is deleted.
 
 Additional watch triggers for global resync:
 
-- `Kuadrant` (`kuadrant.io/v1beta1`) — any create/update/delete triggers reconciliation of all LLMInferenceService
+- `Kuadrant` (`kuadrant.io/v1beta1`) -- any create/update/delete triggers reconciliation of all LLMInferenceService
   instances
-- `Authorino` (`operator.authorino.kuadrant.io/v1beta1`) — same global resync behavior
+- `Authorino` (`operator.authorino.kuadrant.io/v1beta1`) -- same global resync behavior
 
 #### Auth Flow Summary
 
@@ -449,22 +451,22 @@ Response (200):
 ```
 
 Error responses: 400 (missing/invalid namespace, wrong method), 401 (missing token), 500 (discovery failure).
-Unauthorized users receive 200 with an empty `gateways` array — not 403 — to avoid leaking namespace existence.
+Unauthorized users receive 200 with an empty `gateways` array -- not 403 -- to avoid leaking namespace existence.
 
 #### Discovery Flow
 
 The discovery follows a three-step process using a dual-client architecture:
 
 1. **RBAC check** (per-request user client): creates a `SelfSubjectAccessReview` to verify the caller can `create
-   llminferenceservices` in the target namespace. This is the authorization gate — the server checks LLMInferenceService
+   llminferenceservices` in the target namespace. This is the authorization gate -- the server checks LLMInferenceService
    permissions, not Gateway read permissions.
 2. **Gateway listing** (ServiceAccount client, cached via controller-runtime): lists all Gateway resources, optionally
    filtered by `GATEWAY_LABEL_SELECTOR`.
 3. **Listener filtering**: for each gateway, evaluates the listener's `AllowedRoutes.Namespaces.From` policy against
    the target namespace:
-    - `All` — any namespace allowed
-    - `Same` (default when nil) — only the gateway's own namespace
-    - `Selector` — matches target namespace labels against the selector (requires a namespace label fetch)
+    - `All` -- any namespace allowed
+    - `Same` (default when nil) -- only the gateway's own namespace
+    - `Selector` -- matches target namespace labels against the selector (requires a namespace label fetch)
 
 Gateway status is derived from conditions: `Ready` when both `Accepted` and `Programmed` are True, `NotReady` when
 either is False, `Unknown` otherwise.
@@ -509,7 +511,7 @@ All DestinationRules are labeled with `llm-d.ai/managed=true` and use `ExportTo:
 visibility. They are garbage-collected via owner references when the LLMInferenceService is deleted, and are
 automatically deleted when the gateway is not Istio-based or the runtime is force-stopped.
 
-#### Gateway Preconditions — AuthPolicy CRD Check
+#### Gateway Preconditions -- AuthPolicy CRD Check
 
 Before creating any HTTPRoute, the distro build calls `ensureGatewayPreconditions()` to verify the AuthPolicy CRD
 (`kuadrant.io/v1`) is available on the cluster. This prevents exposing LLM services without authentication
@@ -517,7 +519,7 @@ infrastructure:
 
 - If the AuthPolicy CRD is **not installed** and `IsAuthEnabled()` returns true: the controller **deletes the
   HTTPRoute** and returns `ErrPreconditionNotMet` with the message "please install Red Hat Connectivity Link"
-- `ErrPreconditionNotMet` is non-retryable — it sets the status condition but does not trigger infinite requeue
+- `ErrPreconditionNotMet` is non-retryable -- it sets the status condition but does not trigger infinite requeue
 - The check can be disabled via `LLMISVC_AUTH_DISABLED=true` environment variable
 
 This is complementary to the odh-model-controller Kuadrant integration: KServe's precondition check ensures the CRD
@@ -544,7 +546,7 @@ The CA key parser supports PKCS8 (RSA, ECDSA, Ed25519) and PKCS1 (RSA-only) form
 
 The distro build adds RBAC markers for OCP resources the controller manages:
 
-- `networking.istio.io/destinationrules` — get, list, watch, create, update, delete
+- `networking.istio.io/destinationrules` -- get, list, watch, create, update, delete
 
 #### Environment Variable Overrides
 
@@ -591,7 +593,7 @@ The distro build adds RBAC markers for OCP resources the controller manages:
   Kuadrant AuthPolicies are consumed downstream by the EPP for flow control and multi-tenant fairness. Strategies
   involving multi-tenant inference should trace the full path from AuthPolicy header injection through EPP flow control.
 - The Gateway Discovery Server (`odh-model-controller/server/`) provides the RHOAI dashboard with RBAC-scoped gateway
-  visibility — users only see gateways they can deploy LLMInferenceService to, respecting Gateway API listener namespace
+  visibility -- users only see gateways they can deploy LLMInferenceService to, respecting Gateway API listener namespace
   policies. Strategies involving custom gateways or multi-tenant gateway topologies should ensure gateways are labeled
   and listeners use appropriate `AllowedRoutes` policies for UI discoverability.
 - On OCP, KServe creates Istio DestinationRules for TLS origination between the gateway and backend services. The
@@ -601,18 +603,18 @@ The distro build adds RBAC markers for OCP resources the controller manages:
 - The `distro` build tag creates a compile-time split between upstream KServe and OCP-specific behavior. Strategies
   involving KServe upstream contributions must ensure OCP-specific code (Istio DRs, service-ca signing,
   AuthPolicy preconditions) remains behind `//go:build distro` and that corresponding no-op `!distro` stubs exist.
-- KServe's `ensureGatewayPreconditions()` prevents HTTPRoute creation without the AuthPolicy CRD on OCP — a
+- KServe's `ensureGatewayPreconditions()` prevents HTTPRoute creation without the AuthPolicy CRD on OCP -- a
   defense-in-depth measure complementing odh-model-controller's AuthPolicy management. Strategies for environments
   without Red Hat Connectivity Link must set `LLMISVC_AUTH_DISABLED=true` or the controller will block route creation.
 - Workload TLS on OCP uses OpenShift service-ca signing rather than self-signed certificates. The controller reads the
   CA signing secret from `openshift-service-ca` namespace. Strategies involving namespace restrictions or network
   policies must allow the KServe controller cross-namespace read access to this secret.
 - Accelerator-specific `LLMInferenceServiceConfig` presets determine which runtime image and hardware configuration a
-  deployment receives. Not all accelerators support all topologies — check the accelerator matrix before planning
+  deployment receives. Not all accelerators support all topologies -- check the accelerator matrix before planning
   multi-node or disaggregated deployments on non-default hardware.
 - The fast-channel mechanism provides an early-access path for new runtime builds without modifying the base channel.
   Fast-channel configs are marked unsupported and can diverge from base-channel images independently.
-- Some accelerators (e.g., IBM Spyre) require more than image substitution — they set accelerator-specific environment
+- Some accelerators (e.g., IBM Spyre) require more than image substitution -- they set accelerator-specific environment
   variables and custom schedulers. Strategies targeting these accelerators must ensure the required infrastructure is
   installed.
 - The `opendatahub.io/recommended-accelerators` and `opendatahub.io/supported-topologies` annotations are consumed by
@@ -627,7 +629,7 @@ The distro build adds RBAC markers for OCP resources the controller manages:
 
 The generated architecture docs describe each component in isolation: KServe's docs cover the v1beta1 InferenceService;
 odh-model-controller's docs cover InferenceService-era security reconciliation; llm-d components have their own upstream
-docs. None of them capture the cross-component integration — how KServe's LLMInferenceService controller orchestrates
+docs. None of them capture the cross-component integration -- how KServe's LLMInferenceService controller orchestrates
 llm-d's EPP, routing sidecar, and WVA; how odh-model-controller layers Kuadrant AuthPolicies and Istio EnvoyFilters on
 top of KServe's Gateway API resources; how KServe's distro build creates Istio DestinationRules, and
 service-ca-signed certificates on OCP; or how Kuadrant-injected fairness headers flow through the EPP for multi-tenant

--- a/overlays/0022-kserve-llm-d-versioned-base-llminferenceserviceconfig.md
+++ b/overlays/0022-kserve-llm-d-versioned-base-llminferenceserviceconfig.md
@@ -1,0 +1,60 @@
+---
+id: "0022"
+title: Versioned base LLMInferenceServiceConfig for revision management across RHOAI upgrades
+status: active
+created: 2026-07-29
+affects:
+  - kserve
+  - odh-model-controller
+  - llm-d-inference-scheduler
+  - llm-d-router
+  - llm-d-kv-cache
+release:
+  - "3.5"
+  - "next"
+provenance:
+  - https://issues.redhat.com/browse/RHOAIENG-40563
+  - https://github.com/opendatahub-io/kserve/pull/999
+  - https://github.com/opendatahub-io/opendatahub-operator/pull/2949
+author: Pierangelo Di Pilato
+superseded_by: null
+---
+
+## Fact
+
+The Kserve module operator creates version-stamped base `LLMInferenceServiceConfig` resources named after the RHOAI 
+version (e.g., `v3-2-0-kserve-config-llm-decode-template`). When KServe reconciles an `LLMInferenceService`, it resolves
+the current version config and persists the versioned config name in `status.annotations`. On RHOAI upgrade, KServe
+continues using the pinned version config, and the Operator retains previous version configs (no removal). Customers
+upgrade by updating `status.annotations` to the new version or removing annotations entirely to track the latest.
+
+This moves revision management to the backend (KServe + Operator) rather than the Dashboard, avoiding the need to
+clone base configs into user namespaces — which would pollute namespaces and complicate GitOps workflows.
+
+See also: [Overlay 0011](0011-kserve-llm-d-architecture.md) for the full LLMInferenceService and
+LLMInferenceServiceConfig architecture, including config inheritance via `spec.baseRefs` and the preset configs
+this versioning scheme applies to.
+
+## Impact on Strategies
+
+- Upgrade strategies for RHOAI must account for versioned base configs: the Operator creates new version-stamped
+  `LLMInferenceServiceConfig` resources on upgrade but does not remove previous versions, so the system namespace
+  accumulates config resources over time.
+- GitOps strategies benefit because users no longer need to clone and manage base configs in their namespaces — the
+  version pin lives in `status.annotations` on the `LLMInferenceService` itself.
+- The Dashboard no longer needs revision management logic for `LLMInferenceService` (unlike `InferenceService` where
+  it clones `ServingRuntime` per instance). Dashboard creates `LLMInferenceService` normally; KServe handles version
+  pinning transparently.
+- Rollback and canary upgrade strategies are supported: different `LLMInferenceService` instances can reference
+  different version configs simultaneously, enabling per-service upgrade sequencing.
+- The config preservation hierarchy documented in [Overlay 0011](0011-kserve-llm-d-architecture.md)
+  (`preserveSchedulerConfig()`) interacts with versioned configs — the version pin determines which base config is
+  used, while the preservation hierarchy determines how scheduler customizations survive within that version.
+
+## Context
+
+The generated architecture docs describe `LLMInferenceServiceConfig` as a static configuration template
+(`spec.baseRefs`). They do not capture the version-stamped naming convention, the Operator's responsibility for
+creating and retaining versioned configs across upgrades, or the `status.annotations` mechanism that pins an
+`LLMInferenceService` to a specific config version. This overlay captures the revision management design before it
+lands in the codebase.

--- a/overlays/0022-kserve-llm-d-versioned-base-llminferenceserviceconfig.md
+++ b/overlays/0022-kserve-llm-d-versioned-base-llminferenceserviceconfig.md
@@ -29,7 +29,9 @@ continues using the pinned version config, and the Operator retains previous ver
 upgrade by updating `status.annotations` to the new version or removing annotations entirely to track the latest.
 
 This moves revision management to the backend (KServe + Operator) rather than the Dashboard, avoiding the need to
-clone base configs into user namespaces — which would pollute namespaces and complicate GitOps workflows.
+clone base configs into user namespaces -- which would pollute namespaces and complicate GitOps workflows. It also
+prevents automatic runtime upgrades on RHOAI rollout -- existing deployments stay on their pinned config version,
+and users decide when to upgrade.
 
 See also: [Overlay 0011](0011-kserve-llm-d-architecture.md) for the full LLMInferenceService and
 LLMInferenceServiceConfig architecture, including config inheritance via `spec.baseRefs` and the preset configs
@@ -40,7 +42,7 @@ this versioning scheme applies to.
 - Upgrade strategies for RHOAI must account for versioned base configs: the Operator creates new version-stamped
   `LLMInferenceServiceConfig` resources on upgrade but does not remove previous versions, so the system namespace
   accumulates config resources over time.
-- GitOps strategies benefit because users no longer need to clone and manage base configs in their namespaces — the
+- GitOps strategies benefit because users no longer need to clone and manage base configs in their namespaces -- the
   version pin lives in `status.annotations` on the `LLMInferenceService` itself.
 - The Dashboard no longer needs revision management logic for `LLMInferenceService` (unlike `InferenceService` where
   it clones `ServingRuntime` per instance). Dashboard creates `LLMInferenceService` normally; KServe handles version
@@ -48,7 +50,7 @@ this versioning scheme applies to.
 - Rollback and canary upgrade strategies are supported: different `LLMInferenceService` instances can reference
   different version configs simultaneously, enabling per-service upgrade sequencing.
 - The config preservation hierarchy documented in [Overlay 0011](0011-kserve-llm-d-architecture.md)
-  (`preserveSchedulerConfig()`) interacts with versioned configs — the version pin determines which base config is
+  (`preserveSchedulerConfig()`) interacts with versioned configs -- the version pin determines which base config is
   used, while the preservation hierarchy determines how scheduler customizations survive within that version.
 
 ## Context


### PR DESCRIPTION
Add overlay 0022 documenting the versioned base LLMInferenceServiceConfig naming scheme for revision management across RHOAI upgrades. Extend overlay 0011 with accelerator-specific config presets (Kustomize composition pattern, annotation contract, fast channels) and LLMInferenceServiceConfig deletion protection (finalizer, ConfigInUse condition, well-known config webhook). Cross-references added between both overlays.

Using 0022 to not clash with https://github.com/opendatahub-io/architecture-context/pull/43/changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the KServe and llm-d architecture documentation with revised component responsibilities.
  * Added guidance on configuration deletion protection, usage tracking, and deletion warnings.
  * Documented accelerator-specific configuration presets, fast-channel variants, and hardware-aware scheduling.
  * Added a new overlay describing versioned configuration resources, upgrade handling, GitOps workflows, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->