### PR TITLE
feat(overlay-0015): fix stale P/Z template naming, add AIPCC migration context

### DIFF
--- a/overlays/0015-vllm-variant-architecture.md
+++ b/overlays/0015-vllm-variant-architecture.md
@@ -1,6 +1,6 @@
 ---
 id: "0015"
-title: vLLM variant architecture — accelerator matrix, test suite structure, and RHAII boundary
+title: vLLM variant architecture -- accelerator matrix, test suite structure, and RHAII boundary
 status: active
 created: 2026-06-13
 affects:
@@ -41,7 +41,7 @@ vLLM supports 7 platform variants across 6 platform templates in
 
 Additional templates exist for multi-node (`vllm-multinode-template.yaml`) and Spyre ppc64le/s390x variants.
 
-OOTB vLLM templates reference `registry.redhat.io` images by SHA256 digest (via operator `params.env`; GPU variants managed by RHAII, CPU/Spyre variants by IBM teams) — not floating tags. Digest alignment is verified by `image_validation/` tests in `opendatahub-tests`.
+OOTB vLLM templates reference `registry.redhat.io` images by SHA256 digest (via operator `params.env`; GPU variants managed by RHAII, CPU/Spyre variants by IBM teams) -- not floating tags. Digest alignment is verified by `image_validation/` tests in `opendatahub-tests`.
 
 The `TEMPLATE_MAP` in `tests/model_serving/model_runtime/vllm/constant.py` resolves accelerator type to template:
 
@@ -56,11 +56,11 @@ cpu_z     -> vllm-cpu-runtime-template   (combined ppc64le/s390x)
 ```
 
 **Known issue (partially resolved):** The test constants in `utilities/constants.py` originally defined
-`VLLM_CPU_POWER = "vllm-cpu-power-runtime-template"` and `VLLM_CPU_Z = "vllm-cpu-z-runtime-template"` —
+`VLLM_CPU_POWER = "vllm-cpu-power-runtime-template"` and `VLLM_CPU_Z = "vllm-cpu-z-runtime-template"` --
 names that do not match the deployed template (`vllm-cpu-runtime-template`). `ServingRuntimeFromTemplate`
 does exact name matching (Kubernetes API lookup by `metadata.name`), so these would cause
-`ResourceNotFoundError` on real clusters. Tests haven't failed because CI has no P/Z clusters — they're
-always skipped via markers. PR #2081 fixes `VLLM_CPU_POWER` but leaves `VLLM_CPU_Z` incorrect —
+`ResourceNotFoundError` on real clusters. Tests haven't failed because CI has no P/Z clusters -- they're
+always skipped via markers. PR #2081 fixes `VLLM_CPU_POWER` but leaves `VLLM_CPU_Z` incorrect --
 [comment posted](https://github.com/opendatahub-io/opendatahub-tests/pull/2081#issuecomment-5246464458)
 requesting the Z fix before merge.
 
@@ -91,9 +91,9 @@ Model Runtimes team owns:
 - RHOAI-side integration for P/Z: imageParamMap overrides, RELATED_IMAGE entries, Renovate coordination
 - Code review of IBM P&Z test PRs (Raghul as reviewer)
 
-IBM P&Z teams own (test execution delegated Jul 2, 2026 — [thread](https://redhat-internal.slack.com/archives/C07KPDHBR4J/p1781794845166499)):
-- `opendatahub-tests/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/` — test authoring, execution, failure investigation
-- Running tests on Power (ppc64le) and Z (s390x) clusters — MR has no access to this hardware
+IBM P&Z teams own (test execution delegated Jul 2, 2026 -- [thread](https://redhat-internal.slack.com/archives/C07KPDHBR4J/p1781794845166499)):
+- `opendatahub-tests/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/` -- test authoring, execution, failure investigation
+- Running tests on Power (ppc64le) and Z (s390x) clusters -- MR has no access to this hardware
 - Extending test coverage for new P/Z models (e.g., PR #2081 by Pankhudi Jain)
 - Key contacts: Modassar Rana (@morana, Z), npanpali (@npanpali, Power), Pankhudi Jain (@panjain, tests)
 
@@ -128,39 +128,39 @@ covered by the RHAII team:
 
 ```text
 tests/model_serving/model_runtime/vllm/
-├── conftest.py          # Main fixtures: serving_runtime, vllm_inference_service (external_route=True)
-├── constant.py          # TEMPLATE_MAP, ACCELERATOR_IDENTIFIER, queries with keywords
-├── utils.py             # run_raw_inference (external route), validate_raw_openai_inference_request
-├── s3/                  # S3-backed raw deployment
-│   ├── test_granite_7b_starter.py
-│   └── test_llama3_8B_instruct.py
-├── modelcar/            # OCI modelcar YAML-driven validation
-│   ├── conftest.py      # pytest_generate_tests reads YAML config
-│   ├── sample_modelcar_config.yaml
-│   ├── test_modelvalidation.py
-│   └── utils.py
-├── pvc/                 # PVC-backed model storage
-│   ├── conftest.py
-│   └── test_vllm_pvc_inference.py
-├── probes/              # Readiness/liveness probe validation
-│   ├── conftest.py      # probes_serving_runtime with httpGet injection
-│   ├── test_vllm_probes.py
-│   └── utils.py         # VLLM_READINESS_PROBE, VLLM_LIVENESS_PROBE definitions
-└── cpu/                 # CPU variant testing
-    ├── cpu_x86/
-    │   ├── conftest.py  # cpu_x86_serving_runtime, cpu_x86_inference_service
-    │   ├── constant.py  # CPU_X86_ENV_VARIABLES, resources, serving args
-    │   ├── test_vllm_cpu_s3_inference.py
-    │   └── utils.py
-    └── ibm_power_z/
-        ├── conftest.py
-        ├── constant.py  # bfloat16, 12 CPU / 64Gi resources
-        ├── test_falcon3_7b_instruct.py
-        ├── test_granite_3_1_8b_instruct.py
-        ├── test_llama_3_2_1b_instruct.py
-        ├── test_mistral_7b_instruct.py
-        ├── test_phi_4.py
-        └── utils.py
+|-- conftest.py          # Main fixtures: serving_runtime, vllm_inference_service (external_route=True)
+|-- constant.py          # TEMPLATE_MAP, ACCELERATOR_IDENTIFIER, queries with keywords
+|-- utils.py             # run_raw_inference (external route), validate_raw_openai_inference_request
+|-- s3/                  # S3-backed raw deployment
+|   |-- test_granite_7b_starter.py
+|   `-- test_llama3_8B_instruct.py
+|-- modelcar/            # OCI modelcar YAML-driven validation
+|   |-- conftest.py      # pytest_generate_tests reads YAML config
+|   |-- sample_modelcar_config.yaml
+|   |-- test_modelvalidation.py
+|   `-- utils.py
+|-- pvc/                 # PVC-backed model storage
+|   |-- conftest.py
+|   `-- test_vllm_pvc_inference.py
+|-- probes/              # Readiness/liveness probe validation
+|   |-- conftest.py      # probes_serving_runtime with httpGet injection
+|   |-- test_vllm_probes.py
+|   `-- utils.py         # VLLM_READINESS_PROBE, VLLM_LIVENESS_PROBE definitions
+`-- cpu/                 # CPU variant testing
+    |-- cpu_x86/
+    |   |-- conftest.py  # cpu_x86_serving_runtime, cpu_x86_inference_service
+    |   |-- constant.py  # CPU_X86_ENV_VARIABLES, resources, serving args
+    |   |-- test_vllm_cpu_s3_inference.py
+    |   `-- utils.py
+    `-- ibm_power_z/
+        |-- conftest.py
+        |-- constant.py  # bfloat16, 12 CPU / 64Gi resources
+        |-- test_falcon3_7b_instruct.py
+        |-- test_granite_3_1_8b_instruct.py
+        |-- test_llama_3_2_1b_instruct.py
+        |-- test_mistral_7b_instruct.py
+        |-- test_phi_4.py
+        `-- utils.py
 ```
 
 ### Test Markers
@@ -186,7 +186,7 @@ InferenceService (external_route=True) -> ODH Model Controller creates Route
                                        -> /v1/completions, /v1/chat/completions, /v1/models
 ```
 
-gRPC is NOT used — all vLLM tests are REST-only (OpenAI-compatible API).
+gRPC is NOT used -- all vLLM tests are REST-only (OpenAI-compatible API).
 
 The `run_raw_inference()` function uses `@retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))`
 for resilience against transient route propagation delays.
@@ -267,7 +267,7 @@ with `--dtype=bfloat16`.
 
 ## Impact on Strategies
 
-- Strategies involving new vLLM GPU accelerator support (CUDA, ROCm, Gaudi) must go to RHAII — they own those
+- Strategies involving new vLLM GPU accelerator support (CUDA, ROCm, Gaudi) must go to RHAII -- they own those
   engine builds. Model Runtimes only tests the operator integration.
 - Strategies for IBM CPU variants (x86, Power, Z) must coordinate with the respective IBM teams who maintain
   the `red-hat-data-services/vllm-cpu` fork. Model Runtimes tests integration only.
@@ -276,13 +276,13 @@ with `--dtype=bfloat16`.
   resources/env vars, new conftest with serving_runtime and inference_service fixtures, new test module.
 - Strategies involving vLLM CPU Power/Z build migration (RHAISTRAT-2304) affect the image source, not the
   template YAML. From the Model Runtimes perspective, the migration is a digest swap in the operator's
-  `params.env` or `imageParamMap` — no template changes needed unless the runtime version annotation changes.
+  `params.env` or `imageParamMap` -- no template changes needed unless the runtime version annotation changes.
   The operator's `RELATED_IMAGE_ODH_VLLM_CPU_IMAGE` (or new `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE`) entry
   must be updated to point to the RHAII-built image.
 - Any strategy proposing to add vLLM engine features (multimodal, tool calling, etc.) to the Model Runtimes test
-  suite is out of scope — these are RHAII responsibility.
+  suite is out of scope -- these are RHAII responsibility.
 - Strategies for PVC, S3, or OCI modelcar storage improvements affect the Model Runtimes test suite directly.
-- **gRPC support for vLLM is NOT in scope** — vLLM OOTB templates are REST-only (OpenAI API). Any gRPC
+- **gRPC support for vLLM is NOT in scope** -- vLLM OOTB templates are REST-only (OpenAI API). Any gRPC
   strategy for vLLM (TGIS, KServe v2 gRPC) is RHAII engine scope, not Model Runtimes.
 
 ## Context

--- a/overlays/0015-vllm-variant-architecture.md
+++ b/overlays/0015-vllm-variant-architecture.md
@@ -7,6 +7,7 @@ affects:
   - vllm
   - odh-model-controller
   - opendatahub-tests
+updated: 2026-08-10
 release:
   - "3.4"
   - "3.5"
@@ -36,8 +37,7 @@ accelerator or CPU architecture:
 | `gaudi` | `vllm-gaudi-runtime-template` | RHAII | `habana.ai/gaudi` |
 | `spyre` | `vllm-spyre-x86-runtime-template` | IBM Spyre team (`red-hat-data-services/vllm-spyre`) | `ibm.com/spyre_pf` |
 | `cpu_x86` | `vllm-cpu-x86-runtime-template` | IBM (`red-hat-data-services/vllm-cpu`) | CPU label |
-| `cpu_power` | `vllm-cpu-power-runtime-template` | IBM Power team (`red-hat-data-services/vllm-cpu`, ppc64le) | CPU label |
-| `cpu_z` | `vllm-cpu-z-runtime-template` | IBM Z team (`red-hat-data-services/vllm-cpu`, s390x) | CPU label |
+| `cpu_power` / `cpu_z` | `vllm-cpu-runtime-template` | IBM Power+Z teams (`red-hat-data-services/vllm-cpu`, ppc64le+s390x combined) | CPU label |
 
 Additional templates exist for multi-node (`vllm-multinode-template.yaml`) and Spyre ppc64le/s390x variants.
 
@@ -46,14 +46,20 @@ OOTB vLLM templates reference `registry.redhat.io` images by SHA256 digest (via 
 The `TEMPLATE_MAP` in `tests/model_serving/model_runtime/vllm/constant.py` resolves accelerator type to template:
 
 ```text
-nvidia  -> vllm-cuda-runtime-template
-amd     -> vllm-rocm-runtime-template
-gaudi   -> vllm-gaudi-runtime-template
-spyre   -> vllm-spyre-x86-runtime-template
-cpu_x86 -> vllm-cpu-x86-runtime-template
-cpu_power -> vllm-cpu-power-runtime-template
-cpu_z   -> vllm-cpu-z-runtime-template
+nvidia    -> vllm-cuda-runtime-template
+amd       -> vllm-rocm-runtime-template
+gaudi     -> vllm-gaudi-runtime-template
+spyre     -> vllm-spyre-x86-runtime-template
+cpu_x86   -> vllm-cpu-x86-runtime-template
+cpu_power -> vllm-cpu-runtime-template   (combined ppc64le/s390x)
+cpu_z     -> vllm-cpu-runtime-template   (combined ppc64le/s390x)
 ```
+
+**Known issue:** The test constants in `utilities/constants.py` define `VLLM_CPU_POWER = "vllm-cpu-power-runtime-template"`
+and `VLLM_CPU_Z = "vllm-cpu-z-runtime-template"` — these names do not match the deployed template
+(`vllm-cpu-runtime-template`). The `ibm_power_z/conftest.py` uses `ServingRuntimeFromTemplate(template_name=...)`
+with these stale names. This mismatch needs investigation — either the constants need updating or
+`ServingRuntimeFromTemplate` resolves template names through a different mechanism.
 
 ### RHAII Boundary
 
@@ -67,6 +73,9 @@ IBM teams own (via separate vLLM forks under `red-hat-data-services/`):
   - IBM Power team handles ppc64le arch (VSX kernel optimizations)
   - IBM Z team handles s390x arch (VXE kernel optimizations)
   - x86 CPU variant also built from this fork
+  - **AIPCC migration in progress (RHAISTRAT-2304, targeting 3.6 EA1):** Power/Z builds migrating from
+    RHOAI Konflux pipelines (UBI 9 base, non-hermetic, IBM DevPI + PyPI) to RHAII builds on AIPCC CPU
+    base image (`rhaibi-cpu`). x86 CPU remains separate. Multi-arch ppc64le+s390x in a single image.
 - `red-hat-data-services/vllm-spyre`: IBM Spyre accelerator variant
 
 Model Runtimes team owns:
@@ -254,6 +263,11 @@ with `--dtype=bfloat16`.
 - Strategies for IBM Spyre must coordinate with the IBM Spyre team (`red-hat-data-services/vllm-spyre`).
 - CPU variant strategies should follow the pattern established in PR #1723: new marker, new constant file with
   resources/env vars, new conftest with serving_runtime and inference_service fixtures, new test module.
+- Strategies involving vLLM CPU Power/Z build migration (RHAISTRAT-2304) affect the image source, not the
+  template YAML. From the Model Runtimes perspective, the migration is a digest swap in the operator's
+  `params.env` or `imageParamMap` — no template changes needed unless the runtime version annotation changes.
+  The operator's `RELATED_IMAGE_ODH_VLLM_CPU_IMAGE` (or new `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE`) entry
+  must be updated to point to the RHAII-built image.
 - Any strategy proposing to add vLLM engine features (multimodal, tool calling, etc.) to the Model Runtimes test
   suite is out of scope — these are RHAII responsibility.
 - Strategies for PVC, S3, or OCI modelcar storage improvements affect the Model Runtimes test suite directly.
@@ -267,3 +281,10 @@ a clear boundary. Subsequent PRs (#1713, #1704, #1723, #1730) added external rou
 variants, and multi-GPU support. The generated architecture docs for `vllm` do not reflect this team boundary or the
 new test infrastructure. This overlay documents the current state and provides patterns for skills-based test case
 generation.
+
+August 2026 corrections: The variant matrix previously listed separate `vllm-cpu-power-runtime-template` and
+`vllm-cpu-z-runtime-template` templates. The actual codebase has a single combined `vllm-cpu-runtime-template`
+(`vllm-cpu-template.yaml`) for both ppc64le and s390x. The AIPCC migration (RHAISTRAT-2304) context was added
+to reflect the in-progress build migration from RHOAI Konflux to RHAII on AIPCC base images, targeting 3.6 EA1.
+Sources: `odh-model-controller/config/runtimes/vllm/` file listing, `opendatahub-operator/component-params-env.yaml`,
+Slack `#wg-openshift-ai-power-and-z` ([thread](https://redhat-internal.slack.com/archives/C07KPDHBR4J/p1784295030796149)).

--- a/overlays/0015-vllm-variant-architecture.md
+++ b/overlays/0015-vllm-variant-architecture.md
@@ -55,11 +55,14 @@ cpu_power -> vllm-cpu-runtime-template   (combined ppc64le/s390x)
 cpu_z     -> vllm-cpu-runtime-template   (combined ppc64le/s390x)
 ```
 
-**Known issue:** The test constants in `utilities/constants.py` define `VLLM_CPU_POWER = "vllm-cpu-power-runtime-template"`
-and `VLLM_CPU_Z = "vllm-cpu-z-runtime-template"` — these names do not match the deployed template
-(`vllm-cpu-runtime-template`). The `ibm_power_z/conftest.py` uses `ServingRuntimeFromTemplate(template_name=...)`
-with these stale names. This mismatch needs investigation — either the constants need updating or
-`ServingRuntimeFromTemplate` resolves template names through a different mechanism.
+**Known issue (partially resolved):** The test constants in `utilities/constants.py` originally defined
+`VLLM_CPU_POWER = "vllm-cpu-power-runtime-template"` and `VLLM_CPU_Z = "vllm-cpu-z-runtime-template"` —
+names that do not match the deployed template (`vllm-cpu-runtime-template`). `ServingRuntimeFromTemplate`
+does exact name matching (Kubernetes API lookup by `metadata.name`), so these would cause
+`ResourceNotFoundError` on real clusters. Tests haven't failed because CI has no P/Z clusters — they're
+always skipped via markers. PR #2081 fixes `VLLM_CPU_POWER` but leaves `VLLM_CPU_Z` incorrect —
+[comment posted](https://github.com/opendatahub-io/opendatahub-tests/pull/2081#issuecomment-5246464458)
+requesting the Z fix before merge.
 
 ### RHAII Boundary
 
@@ -83,8 +86,16 @@ Model Runtimes team owns:
 - Storage backends: S3, PVC, OCI modelcar
 - Deployment modes: RawDeployment with external routes
 - Health probes: readiness and liveness validation
-- CPU variant testing: x86, IBM Power, IBM Z (testing the operator integration, not the engine)
+- CPU x86 variant testing (testing the operator integration, not the engine)
 - Image validation: sha256 digests, registry.redhat.io sourcing
+- RHOAI-side integration for P/Z: imageParamMap overrides, RELATED_IMAGE entries, Renovate coordination
+- Code review of IBM P&Z test PRs (Raghul as reviewer)
+
+IBM P&Z teams own (test execution delegated Jul 2, 2026 — [thread](https://redhat-internal.slack.com/archives/C07KPDHBR4J/p1781794845166499)):
+- `opendatahub-tests/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/` — test authoring, execution, failure investigation
+- Running tests on Power (ppc64le) and Z (s390x) clusters — MR has no access to this hardware
+- Extending test coverage for new P/Z models (e.g., PR #2081 by Pankhudi Jain)
+- Key contacts: Modassar Rana (@morana, Z), npanpali (@npanpali, Power), Pankhudi Jain (@panjain, tests)
 
 ### Protocol: REST Only (No gRPC)
 

--- a/overlays/0015-vllm-variant-architecture.md
+++ b/overlays/0015-vllm-variant-architecture.md
@@ -27,8 +27,8 @@ superseded_by: null
 
 ### Variant Matrix
 
-vLLM ships as 7 platform templates in `odh-model-controller/config/runtimes/`, each targeting a different
-accelerator or CPU architecture:
+vLLM supports 7 platform variants across 6 platform templates in
+`odh-model-controller/config/runtimes/` (Power and Z share `vllm-cpu-runtime-template`):
 
 | Accelerator Type | Template Name | Image Owner | Resource Identifier |
 |-----------------|---------------|-------------|---------------------|


### PR DESCRIPTION
## Summary

Corrects factual errors in overlay 0015 (vLLM variant architecture) and adds context for the in-progress AIPCC build migration (RHAISTRAT-2304).

**21 lines added, 9 corrected** across 5 change areas, sourced from `odh-model-controller/config/runtimes/vllm/` file listing, `opendatahub-operator/component-params-env.yaml`, `opendatahub-tests/utilities/constants.py`, and Slack `#wg-openshift-ai-power-and-z` discussion threads.

## Changes

### Corrections
- **Variant Matrix** — Merged separate `vllm-cpu-power-runtime-template` and `vllm-cpu-z-runtime-template` rows into a single combined `vllm-cpu-runtime-template` row. The codebase has one template file (`vllm-cpu-template.yaml`) for both ppc64le and s390x — separate templates never existed.
- **TEMPLATE_MAP** — Updated to show the actual deployed template name (`vllm-cpu-runtime-template`) for both `cpu_power` and `cpu_z` accelerator types.
- **Test constant naming mismatch** — Documented that `utilities/constants.py` defines `VLLM_CPU_POWER = "vllm-cpu-power-runtime-template"` and `VLLM_CPU_Z = "vllm-cpu-z-runtime-template"` — these don't match the deployed template name. Flagged for investigation.

### New content
- **AIPCC migration context** — Added note under RHAII Boundary documenting the in-progress migration (RHAISTRAT-2304): Power/Z builds moving from RHOAI Konflux (UBI 9 base, non-hermetic) to RHAII on AIPCC CPU base image (`rhaibi-cpu`), targeting 3.6 EA1.
- **Impact on Strategies** — Added guidance that P/Z build migration is a digest swap from the Model Runtimes perspective — no template YAML changes needed, only operator `params.env`/`imageParamMap` and `RELATED_IMAGE` updates.

## Why these are needed

The overlay previously documented template names that don't exist in the codebase. Strategy pipelines using this overlay for vLLM CPU context would incorrectly assume separate Power and Z templates need separate updates. The AIPCC migration context was missing entirely — future STRATs touching vLLM CPU P/Z builds would rediscover the migration from scratch.

## Relationship to existing overlays
- Companion fix to **PR #64** (overlay 0014) which corrects the same P/Z template naming in the Component Ownership Map
- References **0017-aipcc-base-images** for `rhaibi-cpu` base image availability (ppc64le + s390x supported)
- References **0014** for IBM team ownership boundaries

## Checklist

- [x] Only `overlays/` modified — no changes to `architecture/`
- [x] YAML frontmatter follows schema (id, title, status, created, updated, affects, release, provenance, author)
- [x] Three body sections present: `## Fact`, `## Impact on Strategies`, `## Context`
- [x] Content is factual with provenance links — no opinions or future plans
- [x] Passes `scripts/lint_overlays.py` validation
- [x] All facts verified against current source (template file listing, test constants, operator params)

Made with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the overlay date and corrected accelerator and template mappings.
  * Documented stale test constants and the ongoing AIPCC Power/Z image migration.
  * Clarified ownership and testing boundaries.
  * Added guidance for required related-image updates.
  * Included correction sources for August 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->