### PR TITLE
feat: support manifests-config.yaml as alternative to get_all_manifests.sh

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -44,7 +44,11 @@ def resolve_script_path(
     script_path: str = None,
 ) -> str:
     """
-    Resolve the path to get_all_manifests.sh.
+    Resolve the path to the operator manifest source.
+
+    Returns the path to get_all_manifests.sh if it exists, otherwise
+    manifests-config.yaml. If neither exists, returns the shell script
+    path so the caller produces the familiar error message.
 
     Args:
         platform: Platform type (odh or rhoai)
@@ -55,7 +59,7 @@ def resolve_script_path(
         script_path: Explicit override path (returned as-is if provided)
 
     Returns:
-        Path string to get_all_manifests.sh
+        Path string to get_all_manifests.sh or manifests-config.yaml
     """
     if script_path:
         return script_path
@@ -66,7 +70,16 @@ def resolve_script_path(
     operator_name = "opendatahub-operator" if platform == "odh" else "rhods-operator"
     org_dir = resolve_org_dir(org, suffix=suffix, branch=branch)
 
-    return f"{checkouts_dir}/{org_dir}/{operator_name}/get_all_manifests.sh"
+    operator_dir = f"{checkouts_dir}/{org_dir}/{operator_name}"
+    shell_script = f"{operator_dir}/get_all_manifests.sh"
+    yaml_config = f"{operator_dir}/manifests-config.yaml"
+
+    from pathlib import Path
+    if Path(shell_script).exists():
+        return shell_script
+    if Path(yaml_config).exists():
+        return yaml_config
+    return shell_script
 
 
 def _add_strace_flag(parser):

--- a/lib/manifest_parser.py
+++ b/lib/manifest_parser.py
@@ -1,10 +1,16 @@
-"""Parse opendatahub-operator get_all_manifests.sh script for component info."""
+"""Parse opendatahub-operator manifest sources for component info.
+
+Supports both the legacy get_all_manifests.sh bash script and the newer
+manifests-config.yaml format introduced in rhods-operator PR #3902.
+"""
 
 import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+import yaml
 
 # Repos that are utilities/build-support, not platform components
 EXCLUDED_REPOS = {
@@ -86,6 +92,55 @@ def parse_manifest_array(content: str, array_name: str) -> Dict[str, ComponentIn
     return components
 
 
+def parse_manifests_config(
+    config_path: Path,
+    platform: str,
+) -> Dict[str, ComponentInfo]:
+    """
+    Parse manifests-config.yaml for component repository information.
+
+    The YAML has sections: components, ccmCharts, componentCharts.
+    Each entry has per-platform sub-keys (odh/rhoai) with repo, ref, sourcePath.
+
+    Args:
+        config_path: Path to manifests-config.yaml
+        platform: "odh" or "rhoai"
+
+    Returns:
+        Dict mapping component key to ComponentInfo
+    """
+    data = yaml.safe_load(config_path.read_text())
+    if not isinstance(data, dict):
+        return {}
+
+    components = {}
+    for section in ("components", "ccmCharts", "componentCharts"):
+        entries = data.get(section)
+        if not isinstance(entries, dict):
+            continue
+        for key, platforms in entries.items():
+            if not isinstance(platforms, dict):
+                continue
+            entry = platforms.get(platform)
+            if not isinstance(entry, dict):
+                continue
+            repo = entry.get("repo", "")
+            if "/" not in repo:
+                continue
+            repo_org, repo_name = repo.split("/", 1)
+            ref = entry.get("ref", "")
+            source_folder = entry.get("sourcePath", "")
+            components[key] = ComponentInfo(
+                key=key,
+                repo_org=repo_org,
+                repo_name=repo_name,
+                ref=ref,
+                source_folder=source_folder,
+            )
+
+    return components
+
+
 def find_component_checkouts(
     components: Dict[str, ComponentInfo],
     checkouts_dir: Path
@@ -130,18 +185,16 @@ def process_manifest_script(
     checkouts_dir: Optional[str] = None
 ) -> Dict[str, ComponentInfo]:
     """
-    Process the get_all_manifests.sh script to extract component information.
+    Process a manifest source to extract component information.
+
+    Accepts either get_all_manifests.sh (bash arrays) or
+    manifests-config.yaml (structured YAML). Detection is by filename.
 
     This function is silent - it only processes data and returns structured results.
     Use display_component_summary() for human-readable output.
 
     Args:
-        script_path: Path to the get_all_manifests.sh script
-                    Examples:
-                    - checkouts/opendatahub-io/
-                      opendatahub-operator/get_all_manifests.sh
-                    - checkouts/red-hat-data-services.rhoai-2.14/
-                      opendatahub-operator/get_all_manifests.sh
+        script_path: Path to get_all_manifests.sh or manifests-config.yaml
         platform: Platform type - "odh" or "rhoai"
         checkouts_dir: Base checkouts directory
             (auto-detected from script_path if not provided)
@@ -157,7 +210,7 @@ def process_manifest_script(
 
     if not path.exists():
         raise FileNotFoundError(
-            f"Manifest script not found: {path}\n"
+            f"Manifest source not found: {path}\n"
             "Make sure the operator repository is cloned."
         )
 
@@ -168,7 +221,7 @@ def process_manifest_script(
         #     opendatahub-operator/get_all_manifests.sh
         # or:
         #   checkouts/red-hat-data-services.rhoai-2.14/
-        #     opendatahub-operator/get_all_manifests.sh
+        #     opendatahub-operator/manifests-config.yaml
         parts = path.parts
         if "checkouts" in parts:
             checkouts_idx = parts.index("checkouts")
@@ -180,23 +233,17 @@ def process_manifest_script(
     else:
         checkouts_dir = Path(checkouts_dir)
 
-    content = path.read_text()
-
-    # Determine which array to parse
-    # (try platform-specific first, then fall back to generic)
-    # Newer scripts (3.3+) use ODH_COMPONENT_MANIFESTS / RHOAI_COMPONENT_MANIFESTS
-    # Older scripts (2.25) use COMPONENT_MANIFESTS
-    if platform == "odh":
-        array_name = "ODH_COMPONENT_MANIFESTS"
+    if path.name.endswith(".yaml") or path.name.endswith(".yml"):
+        components = parse_manifests_config(path, platform)
     else:
-        array_name = "RHOAI_COMPONENT_MANIFESTS"
-
-    # Parse the array
-    components = parse_manifest_array(content, array_name)
-
-    # Fall back to generic COMPONENT_MANIFESTS if platform-specific array not found
-    if not components:
-        components = parse_manifest_array(content, "COMPONENT_MANIFESTS")
+        content = path.read_text()
+        if platform == "odh":
+            array_name = "ODH_COMPONENT_MANIFESTS"
+        else:
+            array_name = "RHOAI_COMPONENT_MANIFESTS"
+        components = parse_manifest_array(content, array_name)
+        if not components:
+            components = parse_manifest_array(content, "COMPONENT_MANIFESTS")
 
     if not components:
         return {}

--- a/lib/manifest_parser.py
+++ b/lib/manifest_parser.py
@@ -121,7 +121,8 @@ def parse_manifests_config(
         for key, platforms in entries.items():
             if not isinstance(platforms, dict):
                 continue
-            entry = platforms.get(platform)
+            yaml_key = platform.split("-", 1)[0].split(".", 1)[0]
+            entry = platforms.get(yaml_key)
             if not isinstance(entry, dict):
                 continue
             repo = entry.get("repo", "")
@@ -161,11 +162,12 @@ def find_component_checkouts(
     found_components = {}
 
     for key, component in components.items():
-        # Construct expected checkout path
-        # checkouts_dir is like: checkouts/opendatahub-io
-        # or checkouts/red-hat-data-services.rhoai-2.14
-        # We just append the repo name
-        checkout_path = checkouts_dir / component.repo_name
+        name = component.repo_name
+        if not name or ".." in Path(name).parts or "/" in name or "\\" in name:
+            continue
+        checkout_path = checkouts_dir / name
+        if not checkout_path.resolve().is_relative_to(checkouts_dir.resolve()):
+            continue
 
         if checkout_path.exists() and checkout_path.is_dir():
             component.checkout_path = checkout_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,3 +226,48 @@ def test_resolve_script_path_falls_back_to_yaml(tmp_path: Path):
         checkouts_dir=str(tmp_path / "checkouts"),
     )
     assert result.endswith("manifests-config.yaml")
+
+
+def test_parse_manifests_config_normalizes_versioned_platform(tmp_path: Path):
+    config = tmp_path / "manifests-config.yaml"
+    config.write_text("""\
+components:
+  kserve:
+    rhoai:
+      repo: red-hat-data-services/kserve
+      ref: rhoai-3.6@abc123
+      sourcePath: config
+""")
+    components = parse_manifests_config(config, "rhoai-3.6-ea.1")
+    assert "kserve" in components
+    assert components["kserve"].repo_org == "red-hat-data-services"
+
+
+def test_find_component_checkouts_rejects_path_traversal(tmp_path: Path):
+    from lib.manifest_parser import ComponentInfo, find_component_checkouts
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    checkouts = tmp_path / "checkouts"
+    checkouts.mkdir()
+
+    components = {
+        "evil": ComponentInfo(
+            key="evil",
+            repo_org="org",
+            repo_name="../../outside",
+            ref="main",
+            source_folder="config",
+        ),
+        "good": ComponentInfo(
+            key="good",
+            repo_org="org",
+            repo_name="kserve",
+            ref="main",
+            source_folder="config",
+        ),
+    }
+    (checkouts / "kserve").mkdir()
+    result = find_component_checkouts(components, checkouts)
+    assert "evil" not in result
+    assert "good" in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,11 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from lib.cli import parse_args  # noqa: E402
+from lib.cli import parse_args, resolve_script_path  # noqa: E402
+from lib.manifest_parser import (  # noqa: E402
+    parse_manifests_config,
+    process_manifest_script,
+)
 
 
 def test_generate_architecture_defaults_to_evidence_gated_merge(monkeypatch):
@@ -121,3 +125,104 @@ def test_pipeline_allows_evidence_gated_merge_opt_out(monkeypatch):
     args = parse_args()
 
     assert args.evidence_gated_merge is False
+
+
+def test_parse_manifests_config_extracts_components(tmp_path: Path):
+    config = tmp_path / "manifests-config.yaml"
+    config.write_text("""\
+components:
+  kserve:
+    odh:
+      repo: opendatahub-io/kserve
+      ref: release-v0.17@abc123
+      sourcePath: config
+    rhoai:
+      repo: red-hat-data-services/kserve
+      ref: rhoai-3.5@def456
+      sourcePath: kserve-module/config
+ccmCharts:
+  cert-manager-operator:
+    rhoai:
+      repo: red-hat-data-services/odh-gitops
+      ref: rhoai-3.5@aaa111
+      sourcePath: charts/dependencies/cert-manager-operator
+""")
+    components = parse_manifests_config(config, "rhoai")
+    assert "kserve" in components
+    assert components["kserve"].repo_org == "red-hat-data-services"
+    assert components["kserve"].repo_name == "kserve"
+    assert components["kserve"].ref == "rhoai-3.5@def456"
+    assert components["kserve"].source_folder == "kserve-module/config"
+    assert "cert-manager-operator" in components
+    assert len(components) == 2
+
+
+def test_parse_manifests_config_filters_by_platform(tmp_path: Path):
+    config = tmp_path / "manifests-config.yaml"
+    config.write_text("""\
+components:
+  kserve:
+    odh:
+      repo: opendatahub-io/kserve
+      ref: main@abc123
+      sourcePath: config
+""")
+    components = parse_manifests_config(config, "rhoai")
+    assert len(components) == 0
+
+
+def test_process_manifest_script_dispatches_to_yaml(tmp_path: Path):
+    config = tmp_path / "manifests-config.yaml"
+    checkout = tmp_path / "kserve"
+    checkout.mkdir()
+    config.write_text("""\
+components:
+  kserve:
+    rhoai:
+      repo: test-org/kserve
+      ref: main@abc123
+      sourcePath: config
+""")
+    components = process_manifest_script(
+        str(config), platform="rhoai", checkouts_dir=str(tmp_path),
+    )
+    assert "kserve" in components
+    assert components["kserve"].checkout_path == checkout
+
+
+def test_process_manifest_script_dispatches_to_shell(tmp_path: Path):
+    script = tmp_path / "get_all_manifests.sh"
+    checkout = tmp_path / "kserve"
+    checkout.mkdir()
+    script.write_text("""\
+declare -A RHOAI_COMPONENT_MANIFESTS=(
+    ["kserve"]="test-org:kserve:main@abc123:config"
+)
+""")
+    components = process_manifest_script(
+        str(script), platform="rhoai", checkouts_dir=str(tmp_path),
+    )
+    assert "kserve" in components
+
+
+def test_resolve_script_path_prefers_shell_script(tmp_path: Path):
+    operator_dir = tmp_path / "checkouts" / "org.platform" / "rhods-operator"
+    operator_dir.mkdir(parents=True)
+    (operator_dir / "get_all_manifests.sh").write_text("#!/bin/bash\n")
+    (operator_dir / "manifests-config.yaml").write_text("components: {}\n")
+    result = resolve_script_path(
+        platform="rhoai", org="org", suffix="platform",
+        checkouts_dir=str(tmp_path / "checkouts"),
+    )
+    assert result.endswith("get_all_manifests.sh")
+
+
+def test_resolve_script_path_falls_back_to_yaml(tmp_path: Path):
+    operator_dir = tmp_path / "checkouts" / "org.platform" / "rhods-operator"
+    operator_dir.mkdir(parents=True)
+    (operator_dir / "manifests-config.yaml").write_text("components: {}\n")
+    result = resolve_script_path(
+        platform="rhoai", org="org", suffix="platform",
+        checkouts_dir=str(tmp_path / "checkouts"),
+    )
+    assert result.endswith("manifests-config.yaml")


### PR DESCRIPTION
rhods-operator PR #3902 migrated the bash manifest arrays to a structured YAML file. The manifest parser now detects which format exists and dispatches accordingly. resolve_script_path prefers the shell script when both are present, falling back to the YAML config for newer operator versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for defining manifests in YAML alongside existing shell-based manifests.
  - Manifest information can now be filtered by platform, including component and chart sources.
  - Automatically prioritizes shell-based manifests when both formats are available, with YAML as a fallback.

- **Bug Fixes**
  - Improved handling of missing or malformed manifest entries.
  - Clarified errors when source information is unavailable.
  - Added validation to prevent unsafe component checkout paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->