### PR TITLE
feat: glob branch resolution for extra_repos and add kueue-operator

### DIFF
--- a/docs/plans/002-glob-branch-resolution-for-extra-repos.md
+++ b/docs/plans/002-glob-branch-resolution-for-extra-repos.md
@@ -139,7 +139,7 @@ _rhoai_3x_common: &rhoai_3x_common
       repo: kubeflow-sdk
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh

--- a/docs/plans/002-glob-branch-resolution-for-extra-repos.md
+++ b/docs/plans/002-glob-branch-resolution-for-extra-repos.md
@@ -1,0 +1,211 @@
+# Plan: Glob Branch Resolution for extra_repos
+
+## Goal
+
+Allow `extra_repos` entries in `platforms.yaml` to specify a branch glob
+pattern (e.g., `release-*`) instead of a literal branch name. The pipeline
+resolves the pattern at fetch time by querying remote refs and selecting the
+latest matching branch using numeric version sorting.
+
+Immediate use case: add `openshift/kueue-operator` to the `_rhoai_3x_common`
+base template with `branch: "release-*"`, so each pipeline run automatically
+clones the latest `release-X.Y` branch without manual pin updates.
+
+## Context
+
+Branch values in `platforms.yaml` are currently literal strings passed directly
+to `git clone -b`. There is no template expansion, pattern matching, or version
+sorting. The `_clone_repo` function in `lib/fetch.py` (line 406) receives the
+branch string and passes it verbatim to `git clone`. If the branch does not
+exist, the clone is silently skipped (line 474).
+
+The `openshift/kueue-operator` repo uses `release-X.Y` branches (e.g.,
+`release-1.2`, `release-1.10`). Pinning a literal branch means every new
+release requires a platforms.yaml update. A glob pattern lets the pipeline
+self-resolve to the latest.
+
+## Acceptance Criteria
+
+- [ ] `platforms.yaml` supports glob characters (`*`, `?`) in `branch` values
+      for `extra_repos` entries
+- [ ] When a glob branch is specified, the pipeline queries remote refs,
+      sorts matches by the numeric version suffix, and clones the latest
+- [ ] `openshift/kueue-operator` is added to `_rhoai_3x_common.extra_repos`
+      with `branch: "release-*"`
+- [ ] `kueue-operator` is added to `include_components` in platforms that
+      use the 3.x common template
+- [ ] `scripts/lint_platforms.py` accepts glob characters in branch values
+- [ ] Sorting is numeric (so `release-1.10` sorts after `release-1.2`)
+- [ ] Resolution failure (no matching branches) logs a message and skips
+      the repo, matching existing behavior for missing literal branches
+- [ ] The resolved branch name is logged so runs are reproducible
+
+## Design
+
+### 1. New helper: `_resolve_branch_glob`
+
+Add to `lib/fetch.py`:
+
+```python
+async def _resolve_branch_glob(
+    org: str,
+    repo: str,
+    pattern: str,
+    protocol: str = "https",
+) -> str | None:
+    """Resolve a branch glob pattern to the latest matching branch.
+
+    Queries remote refs with `git ls-remote --heads`, filters by the glob
+    pattern, sorts by the numeric version suffix, and returns the latest.
+    Returns None if no branches match.
+    """
+```
+
+Implementation notes:
+
+- Run `git ls-remote --heads <url> '<pattern>'` to get matching refs.
+  The glob is passed to ls-remote so filtering happens server-side.
+- Parse each ref to extract the branch name (`refs/heads/release-1.10`
+  becomes `release-1.10`).
+- Extract the version suffix after the last `-` (or after a known prefix
+  like `release-`). Split on `.` and compare each segment as an integer.
+  Use `packaging.version.Version` if available, otherwise a simple
+  tuple-of-ints comparison on the numeric suffix.
+- Return the branch name with the highest version, or `None` if no
+  matches.
+
+Sort key example for `release-X.Y`:
+```python
+def _version_sort_key(branch: str) -> tuple:
+    # "release-1.10" -> (1, 10)
+    suffix = branch.rsplit("-", 1)[-1]
+    parts = suffix.split(".")
+    return tuple(int(p) for p in parts if p.isdigit())
+```
+
+This handles `release-1.2` vs `release-1.10` correctly because it
+compares `(1, 2)` vs `(1, 10)` numerically.
+
+### 2. Call site: `_clone_repo`
+
+In `_clone_repo` (`lib/fetch.py`, line 406), before the `git clone`
+subprocess call:
+
+```python
+if branch and any(c in branch for c in ("*", "?")):
+    resolved = await _resolve_branch_glob(org, repo, branch, protocol)
+    if resolved is None:
+        _log(f"  Skipped {org}/{repo} (no branches match '{branch}')")
+        return
+    _log(f"  {org}/{repo}: resolved '{branch}' -> '{resolved}'")
+    branch = resolved
+```
+
+This goes after the URL construction (line 448) and before the
+`cmd = ["git", "clone"]` line (line 457). The rest of `_clone_repo`
+uses the resolved literal branch unchanged.
+
+### 3. Linter update: `scripts/lint_platforms.py`
+
+In `_check_extra_repos` (line 127), the branch validation currently
+only checks `isinstance(entry[opt], str)`. No change needed for type
+validation — glob patterns are strings. However, add a note in the
+platform header comment in `platforms.yaml` documenting that branch
+supports glob patterns.
+
+If the linter ever gains branch-existence checks, those must skip
+glob patterns.
+
+### 4. platforms.yaml changes
+
+**How `extra_repos` and `include_components` relate:** `extra_repos`
+tells the fetch phase to clone a repo. But discovery classifies repos
+from non-primary orgs as "excluded." `include_components` promotes an
+excluded repo back into the component map so it actually gets analyzed.
+They must always be paired for cross-org repos — without
+`include_components`, the repo is cloned but never processed.
+
+Add `kueue-operator` to `_rhoai_3x_common.extra_repos` (line 60):
+
+```yaml
+_rhoai_3x_common: &rhoai_3x_common
+  <<: *rhoai_common
+  extra_orgs:
+    - org: llm-d
+  extra_repos:
+    - org: project-codeflare
+      repo: codeflare-sdk
+    - org: opendatahub-io
+      repo: kubeflow-sdk
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
+    - org: red-hat-data-services
+      repo: models-perf-benchmark-data
+      protocol: ssh
+      exclude_files:
+        - "data/"
+```
+
+Add `kueue-operator` to `include_components` in each platform config
+that inherits `_rhoai_3x_common` and has its own `include_components`
+(since YAML merge does not deep-merge lists):
+
+```yaml
+  include_components:
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
+```
+
+This needs to be added to: `rhoai.next`, `rhoai-3.6-ea.1`, `rhoai-3.5`,
+`rhoai-3.5-ea.2`, `rhoai-3.5-ea.1`, `rhoai-3.4`, `rhoai-3.4-ea.2`,
+`rhoai-3.4-ea.1`. The older platforms (`rhoai-3.3`, `rhoai-3.2`,
+`rhoai-3.0`) inherit `extra_repos` from the anchor without override,
+so they get it automatically — but they will also need
+`include_components` if they don't already declare it.
+
+### 5. Update platforms.yaml header comment
+
+Add to the `branch` field documentation (line 8):
+
+```yaml
+##   branch            - specific branch to clone (skips repos without it)
+##                       supports glob patterns (e.g., "release-*") which
+##                       resolve to the latest matching branch by version sort
+```
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `lib/fetch.py` | Add `_resolve_branch_glob`, call it from `_clone_repo` |
+| `platforms.yaml` | Add kueue-operator entry, update header comment |
+| `scripts/lint_platforms.py` | No code change needed, but verify glob patterns pass |
+
+## Testing
+
+- Unit test `_resolve_branch_glob` with mocked `git ls-remote` output
+  containing `release-1.2`, `release-1.10`, `release-1.9` — verify it
+  returns `release-1.10`.
+- Unit test the sort key with edge cases: single-segment (`release-2`),
+  multi-segment (`release-1.10.3`), non-numeric suffix (ignored/sorted
+  last).
+- Integration: run `python -c "..."` calling `_resolve_branch_glob`
+  against `openshift/kueue-operator` to verify it resolves correctly.
+- Run `make lint` to confirm `lint_platforms.py` accepts the glob branch.
+
+## Risks
+
+- **Network dependency at fetch time**: `git ls-remote` adds an extra
+  network call per glob branch. This is one call per glob entry, not per
+  platform, so the impact is minimal.
+- **Ambiguous sort for non-semver branches**: If a repo has branches like
+  `release-main` alongside `release-1.2`, the version extraction must
+  handle non-numeric suffixes gracefully (skip them or sort them last).
+- **Reproducibility**: Two runs on different days may clone different
+  branches if a new release branch appears. The resolved branch is logged,
+  and the checkout directory records what was actually cloned. Consider
+  logging the resolved branch to a machine-readable location (e.g., the
+  fetch log) for audit purposes.

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -449,7 +449,9 @@ async def _resolve_branch_glob(
         if len(parts) == 2:
             ref = parts[1].strip()
             if ref.startswith("refs/heads/"):
-                branches.append(ref[len("refs/heads/"):])
+                name = ref[len("refs/heads/"):]
+                if "/" not in name and fnmatch.fnmatch(name, pattern):
+                    branches.append(name)
 
     if not branches:
         return None

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -439,7 +439,12 @@ async def _resolve_branch_glob(
         stderr=asyncio.subprocess.PIPE,
         env=env,
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+    except asyncio.TimeoutError:
+        proc.terminate()
+        await proc.wait()
+        return None
     if proc.returncode != 0:
         return None
 
@@ -474,8 +479,48 @@ async def _clone_repo(
     org_dir = f"{org}.{suffix}" if suffix else org
     repo_path = checkouts_dir / org_dir / repo
 
+    if branch and any(c in branch for c in ("*", "?")):
+        resolved = await _resolve_branch_glob(org, repo, branch, protocol)
+        if resolved is None:
+            _log(f"  Skipped {org}/{repo} (no branches match '{branch}')")
+            return
+        _log(f"  {org}/{repo}: resolved '{branch}' -> '{resolved}'")
+        branch = resolved
+
     if repo_path.exists():
         if pull and (repo_path / ".git").exists():
+            if branch:
+                env = _prepare_env()
+                current = await asyncio.create_subprocess_exec(
+                    "git", "rev-parse", "--abbrev-ref", "HEAD",
+                    cwd=str(repo_path),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
+                )
+                cur_out, _ = await current.communicate()
+                current_branch = cur_out.decode().strip()
+                if current_branch != branch:
+                    switch = await asyncio.create_subprocess_exec(
+                        "git", "fetch", "origin", branch,
+                        cwd=str(repo_path),
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        env=env,
+                    )
+                    await switch.communicate()
+                    switch = await asyncio.create_subprocess_exec(
+                        "git", "checkout", branch,
+                        cwd=str(repo_path),
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        env=env,
+                    )
+                    await switch.communicate()
+                    if switch.returncode == 0:
+                        _log(f"  {org}/{repo}: switched {current_branch} -> {branch}")
+                    else:
+                        _log(f"  {org}/{repo}: failed to switch to {branch}")
             env = _prepare_env()
             proc = await asyncio.create_subprocess_exec(
                 "git", "pull", "--ff-only",
@@ -498,14 +543,6 @@ async def _clone_repo(
         if exclude_files:
             _apply_exclude_files(repo_path, exclude_files, repo)
         return
-
-    if branch and any(c in branch for c in ("*", "?")):
-        resolved = await _resolve_branch_glob(org, repo, branch, protocol)
-        if resolved is None:
-            _log(f"  Skipped {org}/{repo} (no branches match '{branch}')")
-            return
-        _log(f"  {org}/{repo}: resolved '{branch}' -> '{resolved}'")
-        branch = resolved
 
     if protocol == "ssh":
         clone_url = f"git@github.com:{org}/{repo}.git"

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -403,6 +403,61 @@ def _apply_exclude_files(repo_path: Path, patterns: list, repo_name: str) -> Non
                 _log(f"  exclude_files [{repo_name}]: removed {rel}")
 
 
+def _version_sort_key(branch: str) -> tuple:
+    """Extract a numeric version tuple from a branch name for sorting.
+
+    Splits on the last '-' and parses the suffix as dot-separated integers.
+    Non-numeric segments are ignored so branches like 'release-main' sort
+    before any numeric version.
+    """
+    suffix = branch.rsplit("-", 1)[-1]
+    parts = suffix.split(".")
+    return tuple(int(p) for p in parts if p.isdigit())
+
+
+async def _resolve_branch_glob(
+    org: str,
+    repo: str,
+    pattern: str,
+    protocol: str = "https",
+) -> str | None:
+    """Resolve a branch glob pattern to the latest matching branch.
+
+    Queries remote refs with ``git ls-remote --heads``, filters by the glob
+    pattern, sorts by the numeric version suffix, and returns the latest.
+    Returns None if no branches match.
+    """
+    if protocol == "ssh":
+        url = f"git@github.com:{org}/{repo}.git"
+    else:
+        url = f"https://github.com/{org}/{repo}.git"
+
+    env = _prepare_env()
+    proc = await asyncio.create_subprocess_exec(
+        "git", "ls-remote", "--heads", url, pattern,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        return None
+
+    branches = []
+    for line in stdout.decode().splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) == 2:
+            ref = parts[1].strip()
+            if ref.startswith("refs/heads/"):
+                branches.append(ref[len("refs/heads/"):])
+
+    if not branches:
+        return None
+
+    branches.sort(key=_version_sort_key)
+    return branches[-1]
+
+
 async def _clone_repo(
     checkouts_dir: Path,
     org: str,
@@ -441,6 +496,14 @@ async def _clone_repo(
         if exclude_files:
             _apply_exclude_files(repo_path, exclude_files, repo)
         return
+
+    if branch and any(c in branch for c in ("*", "?")):
+        resolved = await _resolve_branch_glob(org, repo, branch, protocol)
+        if resolved is None:
+            _log(f"  Skipped {org}/{repo} (no branches match '{branch}')")
+            return
+        _log(f"  {org}/{repo}: resolved '{branch}' -> '{resolved}'")
+        branch = resolved
 
     if protocol == "ssh":
         clone_url = f"git@github.com:{org}/{repo}.git"

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -501,26 +501,33 @@ async def _clone_repo(
                 cur_out, _ = await current.communicate()
                 current_branch = cur_out.decode().strip()
                 if current_branch != branch:
-                    switch = await asyncio.create_subprocess_exec(
+                    fetch = await asyncio.create_subprocess_exec(
                         "git", "fetch", "origin", branch,
                         cwd=str(repo_path),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                         env=env,
                     )
-                    await switch.communicate()
-                    switch = await asyncio.create_subprocess_exec(
+                    await fetch.communicate()
+                    if fetch.returncode != 0:
+                        _log(f"  {org}/{repo}: fetch {branch} failed, skipping")
+                        if exclude_files:
+                            _apply_exclude_files(repo_path, exclude_files, repo)
+                        return
+                    checkout = await asyncio.create_subprocess_exec(
                         "git", "checkout", branch,
                         cwd=str(repo_path),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                         env=env,
                     )
-                    await switch.communicate()
-                    if switch.returncode == 0:
-                        _log(f"  {org}/{repo}: switched {current_branch} -> {branch}")
-                    else:
+                    await checkout.communicate()
+                    if checkout.returncode != 0:
                         _log(f"  {org}/{repo}: failed to switch to {branch}")
+                        if exclude_files:
+                            _apply_exclude_files(repo_path, exclude_files, repo)
+                        return
+                    _log(f"  {org}/{repo}: switched {current_branch} -> {branch}")
             env = _prepare_env()
             proc = await asyncio.create_subprocess_exec(
                 "git", "pull", "--ff-only",

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -66,7 +66,7 @@ _rhoai_3x_common: &rhoai_3x_common
       repo: kubeflow-sdk
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -125,7 +125,7 @@ rhoai.next:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -178,7 +178,7 @@ rhoai-3.6-ea.1:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -231,7 +231,7 @@ rhoai-3.5:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -284,7 +284,7 @@ rhoai-3.5-ea.2:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -337,7 +337,7 @@ rhoai-3.5-ea.1:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -390,7 +390,7 @@ rhoai-3.4:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -443,7 +443,7 @@ rhoai-3.4-ea.2:
       branch: main
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -488,7 +488,7 @@ rhoai-3.4-ea.1:
       repo: ai4rag
     - org: openshift
       repo: kueue-operator
-      branch: "release-*"
+      branch: "release-4.*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -5,7 +5,9 @@
 ##
 ## Fields:
 ##   suffix            - directory suffix for checkouts (e.g., <org>.<suffix>/)
-##   branch            - specific branch to clone (skips repos without it)
+##   branch            - specific branch to clone (skips repos without it);
+##                       supports glob patterns (e.g., "release-*") which
+##                       resolve to the latest matching branch by version sort
 ##   version           - human-readable version string for PLATFORM.md metadata
 ##                       (optional; defaults to branch name, then directory name)
 ##   orgs              - primary GitHub orgs to clone (list of strings)
@@ -62,6 +64,9 @@ _rhoai_3x_common: &rhoai_3x_common
       repo: codeflare-sdk
     - org: opendatahub-io
       repo: kubeflow-sdk
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -118,6 +123,9 @@ rhoai.next:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -144,6 +152,10 @@ rhoai.next:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.6-ea.1:
   <<: *rhoai_3x_common
@@ -164,6 +176,9 @@ rhoai-3.6-ea.1:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -190,6 +205,10 @@ rhoai-3.6-ea.1:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.5:
   <<: *rhoai_3x_common
@@ -210,6 +229,9 @@ rhoai-3.5:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -236,6 +258,10 @@ rhoai-3.5:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.5-ea.2:
   <<: *rhoai_3x_common
@@ -256,6 +282,9 @@ rhoai-3.5-ea.2:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -282,6 +311,10 @@ rhoai-3.5-ea.2:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.5-ea.1:
   <<: *rhoai_3x_common
@@ -302,6 +335,9 @@ rhoai-3.5-ea.1:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -328,6 +364,10 @@ rhoai-3.5-ea.1:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.4:
   <<: *rhoai_3x_common
@@ -348,6 +388,9 @@ rhoai-3.4:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -374,6 +417,10 @@ rhoai-3.4:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.4-ea.2:
   <<: *rhoai_3x_common
@@ -394,6 +441,9 @@ rhoai-3.4-ea.2:
     - org: llm-d-incubation
       repo: llm-d-planner
       branch: main
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -420,6 +470,10 @@ rhoai-3.4-ea.2:
       repo_org: llm-d-incubation
       repo_name: llm-d-planner
       type: service
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.4-ea.1:
   <<: *rhoai_3x_common
@@ -432,6 +486,9 @@ rhoai-3.4-ea.1:
       repo: kubeflow-sdk
     - org: IBM
       repo: ai4rag
+    - org: openshift
+      repo: kueue-operator
+      branch: "release-*"
     - org: red-hat-data-services
       repo: models-perf-benchmark-data
       protocol: ssh
@@ -446,21 +503,40 @@ rhoai-3.4-ea.1:
       repo_org: opendatahub-io
       repo_name: kubeflow-sdk
       type: shared_library
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.3:
   <<: *rhoai_3x_common
   suffix: rhoai-3.3
   branch: rhoai-3.3
+  include_components:
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.2:
   <<: *rhoai_3x_common
   suffix: rhoai-3.2
   branch: rhoai-3.2
+  include_components:
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-3.0:
   <<: *rhoai_3x_common
   suffix: rhoai-3.0
   branch: rhoai-3.0
+  include_components:
+    - key: kueue-operator
+      repo_org: openshift
+      repo_name: kueue-operator
+      type: operator
 
 rhoai-2.25:
   <<: *rhoai_common

--- a/scripts/kueue-test.sh
+++ b/scripts/kueue-test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Quick smoke test: fetch kueue-operator via glob branch resolution,
+# discover components, and run static analysis.
+#
+# Usage:
+#   scripts/kueue-test.sh [PLATFORM]
+#
+# PLATFORM defaults to rhoai-3.6-ea.1 (the current EA release).
+
+set -euo pipefail
+
+PLATFORM="${1:-rhoai-3.6-ea.1}"
+
+uv run python main.py pipeline \
+    --platform "$PLATFORM" \
+    --phase fetch \
+    --phase discover-components \
+    --phase static-analysis \
+    --component kueue-operator \
+    --force
+
+echo ""
+echo "Check architecture/$PLATFORM/kueue-operator/ for output."

--- a/tests/test_branch_glob.py
+++ b/tests/test_branch_glob.py
@@ -63,6 +63,23 @@ class TestResolveBranchGlob:
         assert result == "release-1.10"
 
     @pytest.mark.asyncio
+    async def test_filters_nested_branch_paths(self):
+        output = self._make_ls_remote_output([
+            "konflux/mintmaker/release-1.1/registry.access.redhat.com-ubi9-ubi-minimal-9.x",
+            "konflux/references/release-1.1",
+            "release-1.1",
+            "release-1.4",
+        ])
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (output, b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _resolve_branch_glob("org", "repo", "release-*")
+
+        assert result == "release-1.4"
+
+    @pytest.mark.asyncio
     async def test_returns_none_on_no_matches(self):
         mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"", b"")

--- a/tests/test_branch_glob.py
+++ b/tests/test_branch_glob.py
@@ -67,6 +67,7 @@ class TestResolveBranchGlob:
         output = self._make_ls_remote_output([
             "konflux/mintmaker/release-1.1/registry.access.redhat.com-ubi9-ubi-minimal-9.x",
             "konflux/references/release-1.1",
+            "release-99/registry.access.redhat.com-ubi9-ubi-minimal-9.x",
             "release-1.1",
             "release-1.4",
         ])

--- a/tests/test_branch_glob.py
+++ b/tests/test_branch_glob.py
@@ -1,0 +1,101 @@
+"""Tests for glob branch resolution in lib/fetch.py."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lib.fetch import _resolve_branch_glob, _version_sort_key  # noqa: E402
+
+
+class TestVersionSortKey:
+    def test_single_segment(self):
+        assert _version_sort_key("release-2") == (2,)
+
+    def test_two_segments(self):
+        assert _version_sort_key("release-1.10") == (1, 10)
+
+    def test_three_segments(self):
+        assert _version_sort_key("release-1.10.3") == (1, 10, 3)
+
+    def test_non_numeric_suffix(self):
+        assert _version_sort_key("release-main") == ()
+
+    def test_numeric_sorts_correctly(self):
+        branches = ["release-1.2", "release-1.10", "release-1.9"]
+        result = sorted(branches, key=_version_sort_key)
+        assert result == ["release-1.2", "release-1.9", "release-1.10"]
+
+    def test_mixed_numeric_and_non_numeric(self):
+        branches = ["release-1.2", "release-main", "release-1.10"]
+        result = sorted(branches, key=_version_sort_key)
+        assert result[0] == "release-main"
+        assert result[-1] == "release-1.10"
+
+
+class TestResolveBranchGlob:
+    @pytest.fixture(autouse=True)
+    def _patch_log(self):
+        with patch("lib.fetch._log"):
+            yield
+
+    def _make_ls_remote_output(self, branches: list[str]) -> bytes:
+        lines = []
+        for branch in branches:
+            lines.append(f"abc123\trefs/heads/{branch}")
+        return "\n".join(lines).encode()
+
+    @pytest.mark.asyncio
+    async def test_resolves_latest_branch(self):
+        output = self._make_ls_remote_output(
+            ["release-1.2", "release-1.10", "release-1.9"]
+        )
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (output, b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _resolve_branch_glob("org", "repo", "release-*")
+
+        assert result == "release-1.10"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_no_matches(self):
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _resolve_branch_glob("org", "repo", "release-*")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_git_failure(self):
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"error")
+        mock_proc.returncode = 128
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _resolve_branch_glob("org", "repo", "release-*")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_uses_ssh_url_for_ssh_protocol(self):
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"")
+        mock_proc.returncode = 0
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_exec:
+            await _resolve_branch_glob(
+                "org", "repo", "release-*", protocol="ssh"
+            )
+
+        call_args = mock_exec.call_args[0]
+        assert "git@github.com:org/repo.git" in call_args


### PR DESCRIPTION
Add _resolve_branch_glob to lib/fetch.py which queries git ls-remote, sorts matches by numeric version suffix, and returns the latest. Called from _clone_repo when branch contains glob characters (* or ?).

Add openshift/kueue-operator to _rhoai_3x_common with branch "release-*" so the pipeline auto-resolves to the latest release branch.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving repository branch patterns such as `release-*`, automatically selecting the latest matching version.
  * Added the `kueue-operator` repository to applicable RHOAI 3.x platform configurations.
  * Added a smoke-test script for validating `kueue-operator` integration.

* **Documentation**
  * Documented branch-pattern behavior and configuration.

* **Tests**
  * Added coverage for branch matching, version sorting, failure handling, and repository URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->